### PR TITLE
fix: 阻止全书完成后 Coordinator 派发子代理导致死循环

### DIFF
--- a/assets/prompts/coordinator.md
+++ b/assets/prompts/coordinator.md
@@ -33,6 +33,8 @@ architect 返回后读 `save_foundation` 的 `foundation_ready`：
 
 writer commit 返回 `book_complete=true` 后 Host 不再派发。请输出全书总结（总章数 / 总字数 / 各章概要 / 主要角色弧线 / 伏笔回收）后正常结束。
 
+**禁止在全书完成后调用子代理。** 若用户要求重写、续写或修改已完成的章节，请直接告知"全书已完结，不支持重写或续写。如需再次创作，请新建项目。"不要尝试调用 `subagent`。
+
 ## 工具与子代理
 
 - `subagent(agent, task)`：调用子代理

--- a/internal/agents/build.go
+++ b/internal/agents/build.go
@@ -1,6 +1,7 @@
 package agents
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	"github.com/voocel/ainovel-cli/assets"
 	"github.com/voocel/ainovel-cli/internal/agents/ctxpack"
 	"github.com/voocel/ainovel-cli/internal/bootstrap"
+	"github.com/voocel/ainovel-cli/internal/domain"
 	"github.com/voocel/ainovel-cli/internal/host/reminder"
 	"github.com/voocel/ainovel-cli/internal/rules"
 	"github.com/voocel/ainovel-cli/internal/store"
@@ -261,8 +263,28 @@ func BuildCoordinator(
 		agentcore.WithMaxRetries(subagentMaxRetries),
 		agentcore.WithContextManager(coordinatorEngine),
 		agentcore.WithStopGuard(reminder.NewStopGuard(store, nil)),
+		// phase=complete 时硬拦截 subagent 派发，防止 Writer 死循环。
+		agentcore.WithToolGate(completePhaseGate(store)),
 	)
 	return agent, askUser, restore, coordinatorEngine
+}
+
+// completePhaseGate 返回一个 ToolGate：phase=complete 时拒绝所有 subagent 派发。
+// 防止 Coordinator LLM 在书完成后仍调用 Writer/Architect 导致死循环。
+func completePhaseGate(st *store.Store) agentcore.ToolGate {
+	return func(_ context.Context, req agentcore.GateRequest) (*agentcore.GateDecision, error) {
+		if req.Call.Name != "subagent" {
+			return nil, nil
+		}
+		progress, _ := st.Progress.Load()
+		if progress != nil && progress.Phase == domain.PhaseComplete {
+			return &agentcore.GateDecision{
+				Allowed: false,
+				Reason:  "全书已完成（phase=complete），无法再调用子代理。请告知用户全书已完结，不支持重写或续写。",
+			}, nil
+		}
+		return nil, nil
+	}
 }
 
 type saveFoundationResult struct {

--- a/internal/agents/gate_test.go
+++ b/internal/agents/gate_test.go
@@ -1,0 +1,95 @@
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/voocel/agentcore"
+	"github.com/voocel/ainovel-cli/internal/domain"
+	"github.com/voocel/ainovel-cli/internal/store"
+)
+
+func subagentCall(args string) agentcore.GateRequest {
+	return agentcore.GateRequest{
+		Call: agentcore.ToolCall{Name: "subagent", Args: json.RawMessage(args)},
+	}
+}
+
+func toolCall(name string) agentcore.GateRequest {
+	return agentcore.GateRequest{
+		Call: agentcore.ToolCall{Name: name},
+	}
+}
+
+func newTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	st := store.NewStore(t.TempDir())
+	if err := st.Progress.Init("test", 10); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	return st
+}
+
+func TestCompletePhaseGate_BlocksSubagentAtComplete(t *testing.T) {
+	st := newTestStore(t)
+	if err := st.Progress.UpdatePhase(domain.PhaseComplete); err != nil {
+		t.Fatalf("UpdatePhase: %v", err)
+	}
+
+	gate := completePhaseGate(st)
+	decision, err := gate(context.Background(), subagentCall(`{"agent":"writer","task":"写第 1 章"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if decision == nil || decision.Allowed {
+		t.Fatal("expected gate to block subagent at PhaseComplete")
+	}
+	if decision.Reason == "" {
+		t.Error("expected non-empty reason")
+	}
+}
+
+func TestCompletePhaseGate_AllowsSubagentWhenWriting(t *testing.T) {
+	st := newTestStore(t)
+
+	gate := completePhaseGate(st)
+	decision, err := gate(context.Background(), subagentCall(`{"agent":"writer","task":"写第 1 章"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if decision != nil && !decision.Allowed {
+		t.Fatal("expected gate to allow subagent during Writing phase")
+	}
+}
+
+func TestCompletePhaseGate_AllowsNonSubagentAtComplete(t *testing.T) {
+	st := newTestStore(t)
+	if err := st.Progress.UpdatePhase(domain.PhaseComplete); err != nil {
+		t.Fatalf("UpdatePhase: %v", err)
+	}
+
+	gate := completePhaseGate(st)
+	for _, name := range []string{"novel_context", "ask_user"} {
+		decision, err := gate(context.Background(), toolCall(name))
+		if err != nil {
+			t.Fatalf("tool %s: unexpected error: %v", name, err)
+		}
+		if decision != nil && !decision.Allowed {
+			t.Fatalf("tool %s: expected allow, got block", name)
+		}
+	}
+}
+
+func TestCompletePhaseGate_AllowsWhenNoProgress(t *testing.T) {
+	st := store.NewStore(t.TempDir())
+
+	gate := completePhaseGate(st)
+	decision, err := gate(context.Background(), subagentCall(`{"agent":"writer","task":"写第 1 章"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if decision != nil && !decision.Allowed {
+		t.Fatal("expected gate to allow when progress is nil")
+	}
+}


### PR DESCRIPTION
## Summary

- 书完成后（`phase=complete`）用户要求重写/续写章节时，Coordinator 仍通过 `subagent` 工具派发 Writer，Writer 因 `commit_chapter` 被拒而陷入无限重试（`draft_chapter` → `commit_chapter` 失败 → escalate → Coordinator 重派 → 循环）
- ToolGate 硬拦截：`completePhaseGate` 在 `subagent` 执行前检查 `phase`，`complete` 时直接拒绝派发
- Coordinator prompt 软约束：在"全书完成"段落增加明确规则，优雅拒绝用户的重写/续写请求

## Root Cause

Flow Router（`router.go:69`）在 `phase=complete` 时返回 nil 只覆盖事件驱动的自动派发路径。Coordinator LLM 仍可主动调用 `subagent` 工具派发 Writer。Writer 的 StopGuard 要求产生 commit checkpoint，但 `commit_chapter` 在 `phase=complete` 时拒绝操作 → Writer 永远无法满足 StopGuard → 连续阻拦 3 次后 escalate → Coordinator 可能重派 → 循环。

## Changes

| 文件 | 改动 |
|------|------|
| `internal/agents/build.go` | 新增 `completePhaseGate`，通过 `WithToolGate` 安装到 coordinator |
| `assets/prompts/coordinator.md` | "全书完成"段落增加禁止调用子代理的规则 |
| `internal/agents/gate_test.go` | 新增 4 个单元测试 |

## Test Plan

- `go vet ./...`
- `go test ./...`（新增 4 个测试 + 全量测试通过）
  - `TestCompletePhaseGate_BlocksSubagentAtComplete` — phase=complete 拦截 subagent
  - `TestCompletePhaseGate_AllowsSubagentWhenWriting` — phase!=complete 放行
  - `TestCompletePhaseGate_AllowsNonSubagentAtComplete` — 非 subagent 工具不受影响
  - `TestCompletePhaseGate_AllowsWhenNoProgress` — 无 progress 文件时放行