### PR TITLE
fix: 修复 ollama 免 key 无法启动与示例 base_url 缺 /v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ output/novel/meta/simulation_profile.json
   "model": "qwen3:latest",
   "providers": {
     "ollama": {
-      "base_url": "http://localhost:11434"
+      "base_url": "http://localhost:11434/v1"
     }
   }
 }

--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -19,7 +19,8 @@
     },
     "ollama": {
       // ollama / bedrock / 显式 type 的自定义代理可以省略 api_key
-      "base_url": "http://localhost:11434",
+      // base_url 需带 /v1（ollama 的 OpenAI 兼容端点在 /v1 下）
+      "base_url": "http://localhost:11434/v1",
       "models": ["qwen3:14b"]
     },
     "my-proxy": {

--- a/internal/bootstrap/models.go
+++ b/internal/bootstrap/models.go
@@ -21,6 +21,13 @@ import (
 // 仍小于 RequestTimeout 10 分钟，网络真死时仍能兜底。
 const streamIdleTimeout = 5 * time.Minute
 
+// keylessAPIKeyPlaceholder 是给免鉴权 provider 注入的占位 api_key。
+// litellm 在创建客户端时会无条件要求 api_key 非空（连 ollama 这类本地、
+// 免鉴权 provider 也不例外），这与本项目 RequiresAPIKey 的约定冲突。
+// 对约定为免 key 的 provider 注入该占位值即可通过 litellm 的构造校验；
+// ollama 会忽略 Authorization 头，免鉴权代理同理，不影响实际请求。
+const keylessAPIKeyPlaceholder = "no-key"
+
 // FailoverEvent 表示一次显式 provider 切换。
 // Reason 为短标签（rate_limit / timeout / stream_idle / network），用于结构化日志。
 type FailoverEvent struct {
@@ -270,8 +277,15 @@ func createModelFromConfig(providerKey, model string, pc ProviderConfig, cache m
 		return nil, fmt.Errorf("解析 provider 类型失败: %w", err)
 	}
 
+	apiKey := pc.APIKey
+	if apiKey == "" && !pc.RequiresAPIKey(providerKey) {
+		// 免鉴权 provider（ollama / 显式 type 的代理等）允许不填 api_key，
+		// 但 litellm 构造客户端时仍要求非空，这里注入占位值绕过该校验。
+		apiKey = keylessAPIKeyPlaceholder
+	}
+
 	m, err := llm.NewModel(providerType, model,
-		llm.WithAPIKey(pc.APIKey),
+		llm.WithAPIKey(apiKey),
 		llm.WithBaseURL(pc.BaseURL),
 		llm.WithStreamIdleTimeout(streamIdleTimeout),
 	)

--- a/internal/bootstrap/setup.go
+++ b/internal/bootstrap/setup.go
@@ -46,7 +46,7 @@ var setupProviders = []setupProvider{
 	{name: "qwen", label: "Qwen"},
 	{name: "glm", label: "GLM"},
 	{name: "grok", label: "Grok"},
-	{name: "ollama", label: "Ollama", baseURL: "http://localhost:11434", apiKeyOptional: true},
+	{name: "ollama", label: "Ollama", baseURL: "http://localhost:11434/v1", apiKeyOptional: true},
 	{name: "bedrock", label: "Bedrock", apiKeyOptional: true},
 	{name: "custom", label: "Custom Proxy", needType: true, apiKeyOptional: true},
 }
@@ -183,7 +183,7 @@ func saveExampleConfig() {
       "models": ["gemini-2.5-flash", "gemini-2.5-pro"]
     },
     "ollama": {
-      "base_url": "http://localhost:11434",
+      "base_url": "http://localhost:11434/v1",
       "models": ["qwen3:14b"]
     },
     "bedrock": {


### PR DESCRIPTION
## 问题

复现 #28：使用 ollama 时，按 `config.example.jsonc` 的示例（省略 `api_key`、`base_url` 不带 `/v1`）会启动失败：

```
error: create models: default model: provider ollama (ollama): provider error: llm: ollama: ollama provider validation failed: ollama: API key is required
```

## 根因

1. **api_key 被强制要求**：`createModelFromConfig` → litellm `client.New()` 在构造时**无条件**调用 `provider.Validate()`；`OpenAICompatProvider` 未重写导出的 `Validate()`，沿用 `BaseProvider.Validate()`（只校验 key 非空），**无视 ollama 的 `SkipAPIKeyValidation`**。这与本项目 `RequiresAPIKey("ollama") == false` 的约定冲突，导致免 key provider 报 `API key is required`。

2. **base_url 缺 `/v1`**：示例里显式写 `http://localhost:11434`，会被原样拼成 `/chat/completions`；而 ollama 的 OpenAI 兼容端点在 `/v1` 下，应为 `http://localhost:11434/v1`。

> Ollama 官方文档佐证（`docs/api/openai-compatibility.mdx`）：
> - `base_url='http://localhost:11434/v1/'`
> - `api_key='ollama'  # required but ignored` —— "set the apiKey to **any value**, as it is **not used by Ollama**"

## 改动

- `internal/bootstrap/models.go`：对 `RequiresAPIKey == false` 的 provider 在 `api_key` 为空时注入占位 key（`no-key`），绕过 litellm 构造期校验。ollama 忽略该值；免鉴权自定义代理同理。对 bedrock 无行为变化（其将 `api_key` 解析为 `accessKeyID:secretAccessKey`，无冒号占位后仍报相同的 AWS 凭证缺失错误）。
- `config.example.jsonc` / `internal/bootstrap/setup.go`（向导预填 + 内嵌模板）/ `README.md`：ollama `base_url` 统一补全 `/v1`。

这样既修好了 issue，也让"ollama / 免鉴权代理可省略 api_key"的文档承诺真正成立。

## 验证

- `go build ./...`、`go vet ./internal/bootstrap`：通过
- `gofmt`：改动内容合规
- `go test ./...`：通过（`internal/rules` 有一处 Windows 平台相关的既有失败，与本 PR 无关，已确认在未改动的 main 上同样失败）

Closes #28
