### PR TITLE
feat: 新增 /config 多模型配置与模型级上下文窗口

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ docker compose run --rm ainovel --headless --prompt "写一本悬疑短篇"
 
 ### 配置文件
 
-首次运行时自动引导生成配置文件 `~/.ainovel/config.json`，后续可直接编辑该文件调整设置。删除配置文件后重新运行会再次进入引导流程。
+首次运行时自动引导生成配置文件 `~/.ainovel/config.json`。进入 TUI 后可输入 `/config` 新增或编辑 Provider、保存多个模型并为每个模型设置上下文窗口；保存后立即生效。`/model` 用于在这些已保存模型之间切换。
 
 也可以手动创建配置文件，参考仓库根目录的 `config.example.jsonc`。首次引导也会复制一份到 `~/.ainovel/config.example.jsonc`，方便本机离线查看。
 
@@ -267,7 +267,10 @@ docker compose run --rm ainovel --headless --prompt "写一本悬疑短篇"
     "openrouter": {
       "api_key": "sk-or-v1-xxx",
       "base_url": "https://openrouter.ai/api/v1",
-      "models": ["google/gemini-2.5-flash", "google/gemini-2.5-pro"],
+      "models": [
+        { "name": "google/gemini-2.5-flash", "context_window": 200000 },
+        { "name": "google/gemini-2.5-pro", "context_window": 1000000 }
+      ],
       "extra": {
         "user_agent": "my-client/1.0",
         "headers": { "X-Custom-Client": "my-client" }
@@ -291,11 +294,15 @@ docker compose run --rm ainovel --headless --prompt "写一本悬疑短篇"
 - 标量字段按后者覆盖前者，例如 `provider`、`model`、`reasoning_effort`、`style`
 - `providers` 和 `roles` 按 key 合并，同名项内部按字段覆盖
 - 未填写的字段会继承上层配置，例如项目级配置只写 `base_url` 时会保留全局配置中的 `api_key`
-- 当前不支持用空字符串显式清空上层已有值；如需清空，请直接编辑更高优先级的配置文件
+- 顶层标量当前不支持用空字符串清空上层值；Provider 的 `type` / `api` / `api_key` / `base_url` 可通过 `/config` 显式清空
 
 > ⚠️ `provider`（以及 `roles.*.provider`）的值是 `providers` 里的 **key 名**——一根指针，不是协议名。项目级若把 `provider` 切到一个全局 `providers` 里不存在的账号，必须在项目级同时补上该账号的凭证（`api_key` / `base_url`），否则启动会报“未配置凭证”。
 
-`providers.<name>.models` 为可选字段，用于声明该 provider 下允许在 TUI `/model` 面板中切换的模型列表；如果未配置，系统会回退为当前配置文件里已经出现过的该 provider 模型。
+`providers.<name>.models` 为可选模型对象列表，`name` 是传给 Provider 的模型名，`context_window` 是该模型专属的上下文压缩窗口。旧版字符串数组仍可读取，下一次通过 `/config` 保存时会规范化为对象列表。如果未配置，系统会回退为配置中已经出现过的同 Provider 模型。
+
+上下文窗口按“模型专属值 → 旧顶层 `context_window` → 模型注册表 → 200K 兜底”的顺序解析。它只影响本地上下文压缩时机，不改变远端 API 的真实请求限制。
+
+`/config` 的模型列表中，`A` 新增、`E` 编辑窗口、`D` 删除、`Enter` 设为默认、`S` 进入保存；窗口可输入整数、`128K`、`1M`，留空表示自动解析。保存时可选择全局配置、当前项目配置或本次 `--config` 指定文件，界面会提示更高优先级覆盖风险。API Key 输入始终隐藏。
 
 `reasoning_effort` 为默认推理强度，可选值为 `off` / `low` / `medium` / `high` / `xhigh` / `max`；省略或空字符串表示沿用模型/provider 默认。`roles.<role>.reasoning_effort` 可按角色覆盖，未配置时继承顶层 `reasoning_effort`。TUI `/model` 面板切换 provider、model 或推理强度后，会写回全局配置 `~/.ainovel/config.json`。
 
@@ -456,7 +463,11 @@ output/novel/meta/simulation_profile.json
       "type": "openai",
       "api_key": "sk-xxx",
       "base_url": "https://proxy.example.com/v1",
-      "models": ["gpt-5.4", "gpt-5.4-mini", "MiniMax-M3"],
+      "models": [
+        { "name": "gpt-5.4", "context_window": 400000 },
+        { "name": "gpt-5.4-mini" },
+        { "name": "MiniMax-M3", "context_window": 1000000 }
+      ],
       "api": "responses",
       "extra": {
         "user_agent": "codex-tui/0.142.3 (Mac OS 26.5.1; arm64) Apple_Terminal/470.2 (codex-tui; 0.142.3)",

--- a/cmd/ainovel-cli/main.go
+++ b/cmd/ainovel-cli/main.go
@@ -120,7 +120,7 @@ func runWithConfig(cfg bootstrap.Config, opts cliOptions, args []string) {
 	if opts.Prompt != "" || opts.PromptFile != "" {
 		die("error: --prompt/--prompt-file 仅能在 --headless 模式下使用")
 	}
-	if err := tui.Run(cfg, bundle, versionInfo().Version); err != nil {
+	if err := tui.Run(cfg, bundle, versionInfo().Version, opts.ConfigPath); err != nil {
 		die("error: %v", err)
 	}
 }

--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -2,7 +2,7 @@
   // 默认使用的 provider、model 和推理强度。
   // ★ provider 的值是下面 providers 里的一个 key 名（一根“指针”），不是协议名——
   //   改 provider 必须保证 providers 里有同名条目，否则启动会报“未配置凭证”。
-  //   运行时用 /model 面板切换会写回全局配置 ~/.ainovel/config.json。
+  //   运行时用 /config 管理 Provider/模型库，用 /model 在已保存模型间切换。
   "provider": "openrouter",
   "model": "google/gemini-2.5-flash",
   // 可选。默认推理强度：off / low / medium / high / xhigh / max。
@@ -16,8 +16,11 @@
     "openrouter": {
       "api_key": "sk-or-v1-xxx",
       "base_url": "https://openrouter.ai/api/v1",
-      // 可选。声明 /model 面板候选；省略时回退到配置中已出现过的同 provider 模型。
-      "models": ["google/gemini-3.0-flash", "google/gemini-3.1-pro"],
+      // 可选。声明 /model 面板候选及模型专属上下文窗口；旧字符串数组仍兼容。
+      "models": [
+        { "name": "google/gemini-3.0-flash", "context_window": 200000 },
+        { "name": "google/gemini-3.1-pro", "context_window": 1000000 }
+      ],
       // 可选。透传给该 provider 每次请求的额外参数（采样参数如 temperature/top_p/
       // min_p，或厂商特有键如 nvidia 开 think 的 chat_template_kwargs），逐字并入请求体。
       // 仅对 OpenAI 兼容类 provider 生效（openrouter/deepseek/qwen/glm/grok/ollama…）；
@@ -32,13 +35,13 @@
     },
     "anthropic": {
       "api_key": "sk-ant-xxx",
-      "models": ["claude-sonnet-4", "claude-opus-4"]
+      "models": [{ "name": "claude-sonnet-4" }, { "name": "claude-opus-4" }]
     },
     "ollama": {
       // ollama / bedrock / 显式 type 的自定义代理可以省略 api_key
       // base_url 需带 /v1（ollama 的 OpenAI 兼容端点在 /v1 下）
       "base_url": "http://localhost:11434/v1",
-      "models": ["qwen3:14b"],
+      "models": [{ "name": "qwen3:14b", "context_window": 32768 }],
       // 可选。流式空闲看门狗（Go duration，默认 "5m"）：LocalAI/ollama 等
       // 本地慢推理首块可超 5 分钟，按 provider 放宽，不影响其它通道
       "stream_idle_timeout": "15m"
@@ -50,7 +53,7 @@
       "type": "anthropic",
       "api_key": "sk-xxx",
       "base_url": "https://proxy.example.com",
-      "models": ["claude-sonnet-4-6"],
+      "models": [{ "name": "claude-sonnet-4-6", "context_window": 1000000 }],
       "extra": {
         "user_agent": "claude-code/2.1.183",
         "anthropic_beta": "claude-code-20250219",
@@ -68,7 +71,11 @@
       "type": "openai",
       "api_key": "sk-xxx",
       "base_url": "https://proxy.example.com/v1",
-      "models": ["gpt-5.4", "gpt-5.4-mini", "MiniMax-M3"],
+      "models": [
+        { "name": "gpt-5.4", "context_window": 400000 },
+        { "name": "gpt-5.4-mini" },
+        { "name": "MiniMax-M3", "context_window": 1000000 }
+      ],
       // 可选。OpenAI 协议 endpoint：chat（默认 /v1/chat/completions）/
       // responses（/v1/responses）。Codex 类代理通常需要 responses。
       "api": "responses",
@@ -105,10 +112,8 @@
   // 写作风格：default / suspense / fantasy / romance。
   "style": "default"
 
-  // 可选。显式指定上下文压缩使用的窗口大小。省略 / 0 = 按模型名自动解析
-  //（registry 命中用真实窗口，未命中兜底 200k）。配了就优先用：既能给 registry
-  // 查不到的自定义模型指定真实窗口，也能把名义 1M 窗口钉在 300k 提前触发压缩，
-  // 避免在注意力衰退区才压缩。仅影响压缩阈值，不改变 API 实际请求长度。
+  // 旧版全局上下文窗口，保留作所有模型的回退。优先级低于 models[].context_window，
+  // 高于模型注册表和 200k 默认值。仅影响压缩阈值，不改变 API 实际请求长度。
   // "context_window": 300000
 
   // 可选。单本书（output 目录）的成本预算，挂机保险丝。book_usd > 0 才启用。

--- a/internal/agents/build.go
+++ b/internal/agents/build.go
@@ -159,8 +159,8 @@ func BuildWorkers(
 	editorModel := models.ForRoleWithFailover("editor", reportFailover)
 
 	// Writer 的 ContextManager 由工厂每次调用重建，窗口随模型 swap 动态跟随（见下方工厂）。
-	_, writerModelName, _ := models.CurrentSelection("writer")
-	writerContextWindow, writerSource := cfg.ResolveContextWindow(writerModelName)
+	writerProvider, writerModelName, _ := models.CurrentSelection("writer")
+	writerContextWindow, writerSource := cfg.ResolveContextWindow(writerProvider, writerModelName)
 	bootstrap.LogContextWindowChoice("writer", writerModelName, writerContextWindow, writerSource)
 
 	// modelLookup 写入 session 时给每条 assistant 消息附 _meta:{provider,model}，
@@ -251,7 +251,7 @@ func BuildWorkers(
 		ContextManagerFactory: func(model agentcore.ChatModel) agentcore.ContextManager {
 			// 每次 subagent(writer) 调用都会重建，从当前 runModel 读取最新模型名。
 			// /model 切换 writer 后下一章自动用新窗口。
-			window, _ := cfg.ResolveContextWindow(bootstrap.ModelName(model))
+			window, _ := models.ResolveContextWindow(bootstrap.ModelProvider(model), bootstrap.ModelName(model))
 			return newContextManager(contextManagerConfig{
 				Model:            model,
 				ContextWindow:    window,

--- a/internal/bootstrap/config.example.jsonc
+++ b/internal/bootstrap/config.example.jsonc
@@ -2,7 +2,7 @@
   // 默认使用的 provider、model 和推理强度。
   // ★ provider 的值是下面 providers 里的一个 key 名（一根“指针”），不是协议名——
   //   改 provider 必须保证 providers 里有同名条目，否则启动会报“未配置凭证”。
-  //   运行时用 /model 面板切换会写回全局配置 ~/.ainovel/config.json。
+  //   运行时用 /config 管理 Provider/模型库，用 /model 在已保存模型间切换。
   "provider": "openrouter",
   "model": "google/gemini-2.5-flash",
   // 可选。默认推理强度：off / low / medium / high / xhigh / max。
@@ -16,8 +16,11 @@
     "openrouter": {
       "api_key": "sk-or-v1-xxx",
       "base_url": "https://openrouter.ai/api/v1",
-      // 可选。声明 /model 面板候选；省略时回退到配置中已出现过的同 provider 模型。
-      "models": ["google/gemini-3.0-flash", "google/gemini-3.1-pro"],
+      // 可选。声明 /model 面板候选及模型专属上下文窗口；旧字符串数组仍兼容。
+      "models": [
+        { "name": "google/gemini-3.0-flash", "context_window": 200000 },
+        { "name": "google/gemini-3.1-pro", "context_window": 1000000 }
+      ],
       // 可选。透传给该 provider 每次请求的额外参数（采样参数如 temperature/top_p/
       // min_p，或厂商特有键如 nvidia 开 think 的 chat_template_kwargs），逐字并入请求体。
       // 仅对 OpenAI 兼容类 provider 生效（openrouter/deepseek/qwen/glm/grok/ollama…）；
@@ -32,13 +35,13 @@
     },
     "anthropic": {
       "api_key": "sk-ant-xxx",
-      "models": ["claude-sonnet-4", "claude-opus-4"]
+      "models": [{ "name": "claude-sonnet-4" }, { "name": "claude-opus-4" }]
     },
     "ollama": {
       // ollama / bedrock / 显式 type 的自定义代理可以省略 api_key
       // base_url 需带 /v1（ollama 的 OpenAI 兼容端点在 /v1 下）
       "base_url": "http://localhost:11434/v1",
-      "models": ["qwen3:14b"],
+      "models": [{ "name": "qwen3:14b", "context_window": 32768 }],
       // 可选。流式空闲看门狗（Go duration，默认 "5m"）：LocalAI/ollama 等
       // 本地慢推理首块可超 5 分钟，按 provider 放宽，不影响其它通道
       "stream_idle_timeout": "15m"
@@ -50,7 +53,7 @@
       "type": "anthropic",
       "api_key": "sk-xxx",
       "base_url": "https://proxy.example.com",
-      "models": ["claude-sonnet-4-6"],
+      "models": [{ "name": "claude-sonnet-4-6", "context_window": 1000000 }],
       "extra": {
         "user_agent": "claude-code/2.1.183",
         "anthropic_beta": "claude-code-20250219",
@@ -68,7 +71,11 @@
       "type": "openai",
       "api_key": "sk-xxx",
       "base_url": "https://proxy.example.com/v1",
-      "models": ["gpt-5.4", "gpt-5.4-mini", "MiniMax-M3"],
+      "models": [
+        { "name": "gpt-5.4", "context_window": 400000 },
+        { "name": "gpt-5.4-mini" },
+        { "name": "MiniMax-M3", "context_window": 1000000 }
+      ],
       // 可选。OpenAI 协议 endpoint：chat（默认 /v1/chat/completions）/
       // responses（/v1/responses）。Codex 类代理通常需要 responses。
       "api": "responses",
@@ -105,10 +112,8 @@
   // 写作风格：default / suspense / fantasy / romance。
   "style": "default"
 
-  // 可选。显式指定上下文压缩使用的窗口大小。省略 / 0 = 按模型名自动解析
-  //（registry 命中用真实窗口，未命中兜底 200k）。配了就优先用：既能给 registry
-  // 查不到的自定义模型指定真实窗口，也能把名义 1M 窗口钉在 300k 提前触发压缩，
-  // 避免在注意力衰退区才压缩。仅影响压缩阈值，不改变 API 实际请求长度。
+  // 旧版全局上下文窗口，保留作所有模型的回退。优先级低于 models[].context_window，
+  // 高于模型注册表和 200k 默认值。仅影响压缩阈值，不改变 API 实际请求长度。
   // "context_window": 300000
 
   // 可选。单本书（output 目录）的成本预算，挂机保险丝。book_usd > 0 才启用。

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -21,8 +22,7 @@ const DefaultContextWindow = 200000
 // 0.85 是经验值，给"下一轮 prompt + 大工具结果"留 15% 头部空间，同时让大窗口
 // 模型也能在 85% 主动压缩，避免在 1M 名义窗口下吃满才压（注意力衰退区）。
 //
-// 不暴露给用户配置：与已删除的 context_window 同源——多模型架构下让用户调
-// 数字旋钮反复横跳，不如代码内固定一个合理值。
+// 压缩比例不暴露给用户配置；用户只配置每个模型的真实 context_window。
 const CompactRatio = 0.85
 
 // MinCompactReserve 是 ReserveTokens 的下限。小窗口模型（如 32k 本地 qwen3:8b）
@@ -49,11 +49,11 @@ func CompactReserveTokens(window int) int {
 
 // ProviderConfig 定义单个 LLM 提供商的凭证。
 type ProviderConfig struct {
-	Type    string   `json:"type,omitempty"`     // API 协议类型（openai/anthropic/gemini），自定义代理时指定
-	API     string   `json:"api,omitempty"`      // OpenAI 协议 endpoint：chat（默认）/ responses
-	APIKey  string   `json:"api_key,omitempty"`  // API Key
-	BaseURL string   `json:"base_url,omitempty"` // API Base URL
-	Models  []string `json:"models,omitempty"`   // 可选模型列表，供 TUI 切换时展示
+	Type    string        `json:"type,omitempty"`     // API 协议类型（openai/anthropic/gemini），自定义代理时指定
+	API     string        `json:"api,omitempty"`      // OpenAI 协议 endpoint：chat（默认）/ responses
+	APIKey  string        `json:"api_key,omitempty"`  // API Key
+	BaseURL string        `json:"base_url,omitempty"` // API Base URL
+	Models  []ModelConfig `json:"models,omitempty"`   // 可选模型列表，供 TUI 切换时展示
 	// ExtraBody 透传给该 provider 每次请求的额外参数（如 temperature/top_p/min_p/
 	// presence_penalty，或厂商特有键如 nvidia 开 think 的 chat_template_kwargs）。
 	// OpenAI 兼容端逐字并入请求体（即 extra_body 约定）；值由用户自负其责。
@@ -66,6 +66,124 @@ type ProviderConfig struct {
 	// LocalAI/ollama 等自建慢推理首块可远超 5 分钟，按 provider 放宽即可，
 	// 不拖累其它通道的挂死检测（#79）。
 	StreamIdleTimeout string `json:"stream_idle_timeout,omitempty"`
+
+	typeSet    bool
+	apiSet     bool
+	apiKeySet  bool
+	baseURLSet bool
+	modelsSet  bool
+}
+
+func (pc *ProviderConfig) UnmarshalJSON(data []byte) error {
+	type providerConfigAlias ProviderConfig
+	var decoded providerConfigAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	*pc = ProviderConfig(decoded)
+	_, pc.typeSet = fields["type"]
+	_, pc.apiSet = fields["api"]
+	_, pc.apiKeySet = fields["api_key"]
+	_, pc.baseURLSet = fields["base_url"]
+	_, pc.modelsSet = fields["models"]
+	return nil
+}
+
+func (pc ProviderConfig) MarshalJSON() ([]byte, error) {
+	type providerConfigAlias ProviderConfig
+	data, err := json.Marshal(providerConfigAlias(pc))
+	if err != nil {
+		return nil, err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, err
+	}
+	put := func(enabled bool, name string, value any) error {
+		if !enabled {
+			return nil
+		}
+		raw, err := json.Marshal(value)
+		if err == nil {
+			fields[name] = raw
+		}
+		return err
+	}
+	if err := put(pc.typeSet, "type", pc.Type); err != nil {
+		return nil, err
+	}
+	if err := put(pc.apiSet, "api", pc.API); err != nil {
+		return nil, err
+	}
+	if err := put(pc.apiKeySet, "api_key", pc.APIKey); err != nil {
+		return nil, err
+	}
+	if err := put(pc.baseURLSet, "base_url", pc.BaseURL); err != nil {
+		return nil, err
+	}
+	if err := put(pc.modelsSet, "models", pc.Models); err != nil {
+		return nil, err
+	}
+	return json.Marshal(fields)
+}
+
+func (pc *ProviderConfig) SetType(value string) {
+	pc.Type, pc.typeSet = value, true
+}
+
+func (pc *ProviderConfig) SetAPI(value string) {
+	pc.API, pc.apiSet = value, true
+}
+
+func (pc *ProviderConfig) SetAPIKey(value string) {
+	pc.APIKey, pc.apiKeySet = value, true
+}
+
+func (pc *ProviderConfig) SetBaseURL(value string) {
+	pc.BaseURL, pc.baseURLSet = value, true
+}
+
+func (pc *ProviderConfig) SetModels(value []ModelConfig) {
+	pc.Models, pc.modelsSet = value, true
+}
+
+// ModelConfig 描述某个 provider 下可切换的模型及其可选上下文窗口。
+// 为兼容旧配置，既可从 JSON 字符串（"model-name"）读取，也可从对象读取；
+// 写回时始终规范化为对象形式。
+type ModelConfig struct {
+	Name          string `json:"name"`
+	ContextWindow int    `json:"context_window,omitempty"`
+}
+
+func (m *ModelConfig) UnmarshalJSON(data []byte) error {
+	var legacy string
+	if err := json.Unmarshal(data, &legacy); err == nil {
+		m.Name = legacy
+		m.ContextWindow = 0
+		return nil
+	}
+	type modelConfigAlias ModelConfig
+	var decoded modelConfigAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return fmt.Errorf("model config must be a string or object: %w", err)
+	}
+	*m = ModelConfig(decoded)
+	return nil
+}
+
+// ModelConfig 返回指定模型的显式配置。
+func (pc ProviderConfig) ModelConfig(name string) (ModelConfig, bool) {
+	name = strings.TrimSpace(name)
+	for _, model := range pc.Models {
+		if strings.TrimSpace(model.Name) == name {
+			return model, true
+		}
+	}
+	return ModelConfig{}, false
 }
 
 // defaultStreamIdleTimeout：长输出 + 长 ctx 场景下，reasoning-aware provider
@@ -160,11 +278,8 @@ type Config struct {
 	// 创作参数
 	Style string `json:"style,omitempty"`
 
-	// ContextWindow 上下文压缩使用的窗口大小。留空（0）时按模型名自动解析：
-	// registry 命中用模型真实窗口，未命中兜底 DefaultContextWindow。
-	// 显式配置则优先生效——用于给 registry 查不到的自定义模型指定真实窗口，
-	// 或把大窗口模型钉在更小的值上提前触发压缩（1M 名义窗口在 200k+ 通常已注意力衰退）。
-	// 仅影响压缩阈值，不改变 LLM API 实际请求长度；配置值由用户自负其责。
+	// ContextWindow 是旧版全局上下文窗口，保留为模型专属 context_window 之后的
+	// 兼容回退。仅影响压缩阈值，不改变 LLM API 实际请求长度。
 	ContextWindow int `json:"context_window,omitempty"`
 
 	// Budget 单本书的成本预算政策；book_usd > 0 才启用。
@@ -312,9 +427,21 @@ func validateProviderConfigText(name string, pc ProviderConfig) error {
 			return err
 		}
 	}
+	seenModels := make(map[string]bool, len(pc.Models))
 	for i, model := range pc.Models {
-		if err := validateConfigText(fmt.Sprintf("provider %q models[%d]", name, i), model); err != nil {
+		modelName := strings.TrimSpace(model.Name)
+		if err := validateConfigText(fmt.Sprintf("provider %q models[%d].name", name, i), model.Name); err != nil {
 			return err
+		}
+		if modelName == "" {
+			return fmt.Errorf("provider %q models[%d].name is required: %w", name, i, errs.ErrConfig)
+		}
+		if seenModels[modelName] {
+			return fmt.Errorf("provider %q has duplicate model %q: %w", name, modelName, errs.ErrConfig)
+		}
+		seenModels[modelName] = true
+		if model.ContextWindow < 0 {
+			return fmt.Errorf("provider %q model %q context_window must be >= 0: %w", name, modelName, errs.ErrConfig)
 		}
 	}
 	switch pc.API {
@@ -366,18 +493,25 @@ func (c *Config) FillDefaults() {
 type ContextWindowSource string
 
 const (
-	CtxWindowConfig   ContextWindowSource = "config"   // 配置文件 context_window 显式指定
-	CtxWindowRegistry ContextWindowSource = "registry" // OpenRouter 基线命中
-	CtxWindowDefault  ContextWindowSource = "default"  // 兜底（自定义代理/未知模型）
+	CtxWindowModelConfig ContextWindowSource = "model_config" // provider 模型项显式指定
+	CtxWindowConfig      ContextWindowSource = "config"       // 旧顶层 context_window 显式指定
+	CtxWindowRegistry    ContextWindowSource = "registry"     // OpenRouter 基线命中
+	CtxWindowDefault     ContextWindowSource = "default"      // 兜底（自定义代理/未知模型）
 )
 
 // ResolveContextWindow 解析上下文压缩使用的有效窗口，按优先级：
-//  1. 配置文件 ContextWindow > 0 → 直接用（最高优先级，可超过模型真窗口）
-//  2. models.DefaultRegistry 按模型名查询（OpenRouter 基线 + 24h 刷新）
-//  3. 兜底 DefaultContextWindow（自定义代理 / 未知模型）
+//  1. providers.<provider>.models[].context_window
+//  2. 旧顶层 ContextWindow（兼容已有配置）
+//  3. models.DefaultRegistry 按模型名查询（OpenRouter 基线 + 24h 刷新）
+//  4. 兜底 DefaultContextWindow（自定义代理 / 未知模型）
 //
 // 注意：返回值仅用于压缩阈值计算，不会缩小 LLM API 真实可发请求长度。
-func (c Config) ResolveContextWindow(modelName string) (int, ContextWindowSource) {
+func (c Config) ResolveContextWindow(provider, modelName string) (int, ContextWindowSource) {
+	if pc, ok := c.Providers[strings.TrimSpace(provider)]; ok {
+		if model, found := pc.ModelConfig(modelName); found && model.ContextWindow > 0 {
+			return model.ContextWindow, CtxWindowModelConfig
+		}
+	}
 	if c.ContextWindow > 0 {
 		return c.ContextWindow, CtxWindowConfig
 	}
@@ -405,8 +539,10 @@ func (c Config) ResolveReasoningEffort(role string) string {
 func LogContextWindowChoice(role, model string, window int, source ContextWindowSource) {
 	attrs := []any{"module", "context", "role", role, "model", model, "window", window, "source", source}
 	switch source {
+	case CtxWindowModelConfig:
+		slog.Info("上下文窗口（来自 provider 模型配置）", attrs...)
 	case CtxWindowDefault:
-		slog.Warn("未识别的模型，使用兜底窗口（自定义代理或 OpenRouter 未收录，可用 context_window 显式指定）", attrs...)
+		slog.Warn("未识别的模型，使用兜底窗口（可在 providers.<name>.models[].context_window 显式指定）", attrs...)
 	case CtxWindowConfig:
 		slog.Info("上下文窗口（来自配置文件 context_window）", attrs...)
 	default:
@@ -434,7 +570,7 @@ func (c Config) CandidateModels(provider string) []string {
 
 	if pc, ok := c.Providers[provider]; ok {
 		for _, model := range pc.Models {
-			add(model)
+			add(model.Name)
 		}
 	}
 	if c.Provider == provider {

--- a/internal/bootstrap/configfile.go
+++ b/internal/bootstrap/configfile.go
@@ -50,6 +50,42 @@ func projectConfigPath() string {
 	return filepath.Join(configDirName, "config.json")
 }
 
+// ConfigTarget 是 /config 可选择的配置写入位置。
+type ConfigTarget struct {
+	ID         string
+	Label      string
+	Path       string
+	Precedence int
+	Exists     bool
+}
+
+// ConfigTargets 返回从高到低排列的可写配置目标。flagPath 为空时不提供指定文件项。
+func ConfigTargets(flagPath string) []ConfigTarget {
+	var targets []ConfigTarget
+	seen := make(map[string]bool)
+	add := func(id, label, path string, precedence int) {
+		if path == "" {
+			return
+		}
+		if abs, err := filepath.Abs(path); err == nil {
+			path = abs
+		}
+		path = filepath.Clean(path)
+		if seen[path] {
+			return
+		}
+		seen[path] = true
+		_, err := os.Stat(path)
+		targets = append(targets, ConfigTarget{
+			ID: id, Label: label, Path: path, Precedence: precedence, Exists: err == nil,
+		})
+	}
+	add("flag", "--config 指定文件", flagPath, 3)
+	add("project", "当前项目配置", projectConfigPath(), 2)
+	add("global", "全局配置", DefaultConfigPath(), 1)
+	return targets
+}
+
 // LoadConfig 按优先级加载并合并配置：
 //  1. ~/.ainovel/config.json（全局）
 //  2. ./.ainovel/config.json（项目级覆盖）
@@ -153,20 +189,25 @@ func mergeConfig(base, overlay Config) Config {
 		}
 		for k, v := range overlay.Providers {
 			existing := base.Providers[k]
-			if v.Type != "" {
+			if v.typeSet || v.Type != "" {
 				existing.Type = v.Type
+				existing.typeSet = true
 			}
-			if v.API != "" {
+			if v.apiSet || v.API != "" {
 				existing.API = v.API
+				existing.apiSet = true
 			}
-			if v.APIKey != "" {
+			if v.apiKeySet || v.APIKey != "" {
 				existing.APIKey = v.APIKey
+				existing.apiKeySet = true
 			}
-			if v.BaseURL != "" {
+			if v.baseURLSet || v.BaseURL != "" {
 				existing.BaseURL = v.BaseURL
+				existing.baseURLSet = true
 			}
-			if len(v.Models) > 0 {
-				existing.Models = append([]string(nil), v.Models...)
+			if v.modelsSet || len(v.Models) > 0 {
+				existing.Models = append([]ModelConfig(nil), v.Models...)
+				existing.modelsSet = true
 			}
 			if len(v.ExtraBody) > 0 {
 				existing.ExtraBody = cloneMap(v.ExtraBody)
@@ -221,6 +262,44 @@ func cloneMap(m map[string]any) map[string]any {
 		c[k] = v
 	}
 	return c
+}
+
+// CloneConfig 深拷贝配置中会在运行时修改的 map/slice，避免候选配置污染当前配置。
+func CloneConfig(cfg Config) Config {
+	clone := cfg
+	clone.Providers = make(map[string]ProviderConfig, len(cfg.Providers))
+	for name, pc := range cfg.Providers {
+		pc.Models = append([]ModelConfig(nil), pc.Models...)
+		pc.Extra = cloneMap(pc.Extra)
+		pc.ExtraBody = cloneMap(pc.ExtraBody)
+		clone.Providers[name] = pc
+	}
+	clone.Roles = make(map[string]RoleConfig, len(cfg.Roles))
+	for role, rc := range cfg.Roles {
+		rc.Fallbacks = append([]ModelRef(nil), rc.Fallbacks...)
+		clone.Roles[role] = rc
+	}
+	clone.Notify.Events = append([]string(nil), cfg.Notify.Events...)
+	return clone
+}
+
+// SaveModelConfig 补丁式更新目标配置层的 provider 库和默认模型。
+// 目标不存在时创建最小配置；目标损坏时拒绝覆盖。
+func SaveModelConfig(path string, provider string, pc ProviderConfig, model string) error {
+	target, found, err := loadOptionalJSON(path)
+	if err != nil {
+		return err
+	}
+	if !found {
+		target = Config{}
+	}
+	if target.Providers == nil {
+		target.Providers = make(map[string]ProviderConfig)
+	}
+	target.Provider = provider
+	target.ModelName = model
+	target.Providers[provider] = pc
+	return SaveConfig(path, target)
 }
 
 // stripJSONComments 去除 JSON 中的 // 行注释，跟踪引号状态避免误删字符串内容。
@@ -305,5 +384,33 @@ func SaveConfig(path string, cfg Config) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o644)
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".config-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		_ = tmp.Close()
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := tmp.Write(append(data, '\n')); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }

--- a/internal/bootstrap/model_config_test.go
+++ b/internal/bootstrap/model_config_test.go
@@ -1,0 +1,116 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestModelConfigAcceptsLegacyAndObjectEntries(t *testing.T) {
+	var cfg Config
+	input := `{
+  "provider":"custom","model":"legacy-model",
+  "providers":{"custom":{"type":"openai","models":[
+    "legacy-model",
+    {"name":"large-model","context_window":400000}
+  ]}}
+}`
+	if err := json.Unmarshal([]byte(input), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	models := cfg.Providers["custom"].Models
+	if len(models) != 2 || models[0].Name != "legacy-model" || models[0].ContextWindow != 0 {
+		t.Fatalf("legacy model decode = %#v", models)
+	}
+	if models[1].Name != "large-model" || models[1].ContextWindow != 400000 {
+		t.Fatalf("object model decode = %#v", models[1])
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), `"models":["legacy-model"`) {
+		t.Fatalf("models should be normalized to objects: %s", data)
+	}
+	if !strings.Contains(string(data), `"name":"legacy-model"`) {
+		t.Fatalf("normalized model missing: %s", data)
+	}
+}
+
+func TestResolveContextWindowIsProviderAware(t *testing.T) {
+	cfg := Config{
+		ContextWindow: 300000,
+		Providers: map[string]ProviderConfig{
+			"one": {Models: []ModelConfig{{Name: "same", ContextWindow: 128000}}},
+			"two": {Models: []ModelConfig{{Name: "same", ContextWindow: 900000}}},
+		},
+	}
+	if got, source := cfg.ResolveContextWindow("one", "same"); got != 128000 || source != CtxWindowModelConfig {
+		t.Fatalf("one/same = %d %s", got, source)
+	}
+	if got, source := cfg.ResolveContextWindow("two", "same"); got != 900000 || source != CtxWindowModelConfig {
+		t.Fatalf("two/same = %d %s", got, source)
+	}
+	if got, source := cfg.ResolveContextWindow("one", "unknown"); got != 300000 || source != CtxWindowConfig {
+		t.Fatalf("legacy fallback = %d %s", got, source)
+	}
+}
+
+func TestMergeConfigCanExplicitlyClearProviderFields(t *testing.T) {
+	base := Config{Providers: map[string]ProviderConfig{
+		"proxy": {Type: "openai", API: "responses", APIKey: "secret", BaseURL: "https://old.example/v1"},
+	}}
+	var overlay Config
+	if err := json.Unmarshal([]byte(`{"providers":{"proxy":{"type":"","api":"","api_key":"","base_url":""}}}`), &overlay); err != nil {
+		t.Fatalf("unmarshal overlay: %v", err)
+	}
+	merged := mergeConfig(base, overlay)
+	pc := merged.Providers["proxy"]
+	if pc.Type != "" || pc.API != "" || pc.APIKey != "" || pc.BaseURL != "" {
+		t.Fatalf("explicit clears not applied: %#v", pc)
+	}
+	data, err := json.Marshal(pc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, field := range []string{`"type":""`, `"api":""`, `"api_key":""`, `"base_url":""`} {
+		if !strings.Contains(string(data), field) {
+			t.Errorf("cleared field %s missing from %s", field, data)
+		}
+	}
+}
+
+func TestSaveModelConfigPreservesOtherFieldsAndUsesPrivateMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".ainovel", "config.json")
+	original := Config{
+		Provider: "old", ModelName: "old-model", Style: "fantasy",
+		Providers: map[string]ProviderConfig{"old": {Type: "openai", Models: []ModelConfig{{Name: "old-model"}}}},
+		Budget:    BudgetConfig{BookUSD: 20, WarnRatio: 0.8},
+	}
+	if err := SaveConfig(path, original); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	pc := ProviderConfig{Type: "openai", Models: []ModelConfig{{Name: "new-model", ContextWindow: 500000}}}
+	if err := SaveModelConfig(path, "new", pc, "new-model"); err != nil {
+		t.Fatalf("save model config: %v", err)
+	}
+	got, err := LoadConfigFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.Style != "fantasy" || got.Budget.BookUSD != 20 || got.Provider != "new" || got.ModelName != "new-model" {
+		t.Fatalf("unrelated fields or selection lost: %#v", got)
+	}
+	if _, ok := got.Providers["old"]; !ok {
+		t.Fatal("existing provider was removed")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("config mode = %o, want 600", info.Mode().Perm())
+	}
+}

--- a/internal/bootstrap/models.go
+++ b/internal/bootstrap/models.go
@@ -99,6 +99,7 @@ func (m *SwappableModel) Current() (provider, name string) {
 
 // ModelSet 持有按角色分配的模型实例，未配置的角色回退到默认模型。
 type ModelSet struct {
+	mu        sync.RWMutex
 	Default   *SwappableModel
 	models    map[string]*SwappableModel
 	fallbacks map[string][]modelTarget
@@ -107,6 +108,8 @@ type ModelSet struct {
 
 // ForRole 返回指定角色的模型，未配置时返回默认模型。
 func (ms *ModelSet) ForRole(role string) agentcore.ChatModel {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
 	if m, ok := ms.models[role]; ok {
 		return m
 	}
@@ -116,6 +119,8 @@ func (ms *ModelSet) ForRole(role string) agentcore.ChatModel {
 // ForRoleWithFailover 返回带有单次请求级 fallback 的角色模型。
 // 仅当该角色显式配置了 fallbacks 时生效；未配置时退化为普通模型。
 func (ms *ModelSet) ForRoleWithFailover(role string, report FailoverReporter) agentcore.ChatModel {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
 	primary, ok := ms.models[role]
 	if !ok {
 		return ms.Default
@@ -125,15 +130,14 @@ func (ms *ModelSet) ForRoleWithFailover(role string, report FailoverReporter) ag
 		return primary
 	}
 	return &failoverModel{
-		role:      role,
-		primary:   primary,
-		fallbacks: append([]modelTarget(nil), targets...),
-		report:    report,
+		role: role, primary: primary, set: ms, report: report,
 	}
 }
 
 // Summary 返回模型分配摘要（供日志使用）。
 func (ms *ModelSet) Summary() string {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
 	var parts []string
 	for role, m := range ms.models {
 		provider, name := m.Current()
@@ -150,6 +154,8 @@ func (ms *ModelSet) Summary() string {
 // CurrentSelection 返回角色当前生效的 provider/model。
 // role 为空或 "default" 时返回默认模型。
 func (ms *ModelSet) CurrentSelection(role string) (provider, model string, explicit bool) {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
 	if role == "" || role == "default" {
 		provider, model = ms.Default.Current()
 		return provider, model, true
@@ -165,6 +171,8 @@ func (ms *ModelSet) CurrentSelection(role string) (provider, model string, expli
 // Swap 切换默认模型或指定角色模型。
 // role 为空或 "default" 时切换默认模型；其他角色切换为显式覆盖。
 func (ms *ModelSet) Swap(role, provider, model string) error {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
 	pc, ok := ms.config.Providers[provider]
 	if !ok {
 		return fmt.Errorf("provider %q is not configured: %w", provider, errs.ErrConfig)
@@ -176,6 +184,8 @@ func (ms *ModelSet) Swap(role, provider, model string) error {
 
 	if role == "" || role == "default" {
 		ms.Default.Swap(provider, model, next)
+		ms.config.Provider = provider
+		ms.config.ModelName = model
 		return nil
 	}
 
@@ -185,10 +195,58 @@ func (ms *ModelSet) Swap(role, provider, model string) error {
 
 	if existing, ok := ms.models[role]; ok {
 		existing.Swap(provider, model, next)
-		return nil
+	} else {
+		ms.models[role] = NewSwappableModel(provider, model, next)
 	}
-	ms.models[role] = NewSwappableModel(provider, model, next)
+	if ms.config.Roles == nil {
+		ms.config.Roles = make(map[string]RoleConfig)
+	}
+	rc := ms.config.Roles[role]
+	rc.Provider = provider
+	rc.Model = model
+	ms.config.Roles[role] = rc
 	return nil
+}
+
+// ResolveContextWindow 使用 ModelSet 的最新配置解析窗口，供运行时热切换后的
+// ContextManagerFactory 使用，避免捕获启动时的 Config 副本。
+func (ms *ModelSet) ResolveContextWindow(provider, model string) (int, ContextWindowSource) {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	return ms.config.ResolveContextWindow(provider, model)
+}
+
+// ApplyPrepared 提交一个已成功构建的候选 ModelSet。已有 SwappableModel 的地址
+// 保持不变，因此已装配的 Worker/Arbiter 会在下一次请求自动使用新客户端。
+func (ms *ModelSet) ApplyPrepared(candidate *ModelSet) {
+	if candidate == nil {
+		return
+	}
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	defaultProvider, defaultName := candidate.Default.Current()
+	ms.Default.Swap(defaultProvider, defaultName, candidate.Default.SwappableModel.Current())
+
+	nextModels := make(map[string]*SwappableModel, len(candidate.models))
+	for role, next := range candidate.models {
+		provider, name := next.Current()
+		if existing, ok := ms.models[role]; ok {
+			existing.Swap(provider, name, next.SwappableModel.Current())
+			nextModels[role] = existing
+		} else {
+			nextModels[role] = next
+		}
+	}
+	ms.models = nextModels
+	ms.fallbacks = candidate.fallbacks
+	ms.config = CloneConfig(candidate.config)
+}
+
+func (ms *ModelSet) fallbackTargets(role string) []modelTarget {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	return append([]modelTarget(nil), ms.fallbacks[role]...)
 }
 
 // ModelName 从 ChatModel 中提取当前模型名，失败返回空字符串。
@@ -196,6 +254,17 @@ func (ms *ModelSet) Swap(role, provider, model string) error {
 func ModelName(m agentcore.ChatModel) string {
 	if info, ok := m.(interface{ Info() llm.ModelInfo }); ok {
 		return info.Info().Name
+	}
+	return ""
+}
+
+// ModelProvider 从 ChatModel 中提取当前 provider 名称，失败返回空字符串。
+func ModelProvider(m agentcore.ChatModel) string {
+	if info, ok := m.(interface{ Info() llm.ModelInfo }); ok {
+		return info.Info().Provider
+	}
+	if provider, ok := m.(interface{ ProviderName() string }); ok {
+		return provider.ProviderName()
 	}
 	return ""
 }
@@ -296,10 +365,10 @@ func createModelFromConfig(providerKey, model string, pc ProviderConfig, cache m
 }
 
 type failoverModel struct {
-	role      string
-	primary   *SwappableModel
-	fallbacks []modelTarget
-	report    FailoverReporter
+	role    string
+	primary *SwappableModel
+	set     *ModelSet
+	report  FailoverReporter
 }
 
 func (m *failoverModel) Generate(ctx context.Context, messages []agentcore.Message, tools []agentcore.ToolSpec, opts ...agentcore.CallOption) (*agentcore.LLMResponse, error) {
@@ -418,7 +487,11 @@ func (m *failoverModel) pickFallback(current modelTarget, err error) (modelTarge
 		return modelTarget{}, agentcore.FailoverReason(err), false
 	}
 	reason := agentcore.FailoverReason(err)
-	for _, target := range m.fallbacks {
+	var targets []modelTarget
+	if m.set != nil {
+		targets = m.set.fallbackTargets(m.role)
+	}
+	for _, target := range targets {
 		if target.provider == current.provider && target.name == current.name {
 			continue
 		}

--- a/internal/bootstrap/setup.go
+++ b/internal/bootstrap/setup.go
@@ -44,6 +44,15 @@ type setupProvider struct {
 	apiKeyOptional bool   // true 表示 API Key 允许留空
 }
 
+// ProviderPreset 是首次引导和运行时 /config 共用的 provider 目录项。
+type ProviderPreset struct {
+	Name           string
+	Label          string
+	BaseURL        string
+	NeedType       bool
+	APIKeyOptional bool
+}
+
 var setupProviders = []setupProvider{
 	{name: "openrouter", label: "OpenRouter", baseURL: "https://openrouter.ai/api/v1"},
 	{name: "anthropic", label: "Anthropic"},
@@ -56,6 +65,18 @@ var setupProviders = []setupProvider{
 	{name: "ollama", label: "Ollama", baseURL: "http://localhost:11434/v1", apiKeyOptional: true},
 	{name: "bedrock", label: "Bedrock", apiKeyOptional: true},
 	{name: "custom", label: "Custom Proxy", needType: true, apiKeyOptional: true},
+}
+
+// ProviderPresets 返回一份可安全修改的预设列表。
+func ProviderPresets() []ProviderPreset {
+	out := make([]ProviderPreset, 0, len(setupProviders))
+	for _, preset := range setupProviders {
+		out = append(out, ProviderPreset{
+			Name: preset.name, Label: preset.label, BaseURL: preset.baseURL,
+			NeedType: preset.needType, APIKeyOptional: preset.apiKeyOptional,
+		})
+	}
+	return out
 }
 
 // RunSetup 运行首次引导，返回生成的配置。
@@ -130,6 +151,7 @@ func RunSetup() (Config, error) {
 		return Config{}, err
 	}
 	printStepDone("Model", modelName)
+	pc.Models = []ModelConfig{{Name: modelName}}
 
 	cfg := Config{
 		Provider:  providerName,

--- a/internal/entry/tui/app.go
+++ b/internal/entry/tui/app.go
@@ -13,8 +13,8 @@ import (
 // 1. 快速模式、共创模式属于“启动编排”；
 // 2. 正式创作会话进入 host.Host；
 // 3. 未来若新增“续写已有小说”等共享模式，统一落到 internal/entry/startup。
-func Run(cfg bootstrap.Config, bundle assets.Bundle, version string) error {
-	rt, err := host.New(cfg, bundle)
+func Run(cfg bootstrap.Config, bundle assets.Bundle, version, configPath string) error {
+	rt, err := host.NewWithOptions(cfg, bundle, host.Options{ConfigPath: configPath})
 	if err != nil {
 		return err
 	}

--- a/internal/entry/tui/command_config.go
+++ b/internal/entry/tui/command_config.go
@@ -1,0 +1,660 @@
+package tui
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/voocel/ainovel-cli/internal/bootstrap"
+	"github.com/voocel/ainovel-cli/internal/host"
+	"github.com/voocel/ainovel-cli/internal/utils"
+)
+
+type configStep int
+
+const (
+	configStepProvider configStep = iota
+	configStepCustomName
+	configStepProtocol
+	configStepAPI
+	configStepKeyAction
+	configStepKeyInput
+	configStepBaseURL
+	configStepModels
+	configStepModelName
+	configStepModelWindow
+	configStepTarget
+)
+
+type configProviderChoice struct {
+	label    string
+	existing *host.ProviderSnapshot
+	preset   *bootstrap.ProviderPreset
+	custom   bool
+}
+
+type modelConfigState struct {
+	snapshot host.ModelConfigurationSnapshot
+	step     configStep
+	cursor   int
+	message  string
+	input    string
+	saving   bool
+
+	providerChoices []configProviderChoice
+	provider        string
+	providerType    string
+	api             string
+	baseURL         string
+	models          []bootstrap.ModelConfig
+	defaultModel    string
+	existing        bool
+	hasAPIKey       bool
+	apiKeyOptional  bool
+	apiKeyAction    host.APIKeyAction
+	apiKey          string
+
+	pendingModel string
+	editModelIdx int
+	targetIdx    int
+}
+
+func newModelConfigState(rt *host.Host) *modelConfigState {
+	snapshot := rt.ModelConfiguration()
+	state := &modelConfigState{snapshot: snapshot, editModelIdx: -1}
+	configured := make(map[string]bool, len(snapshot.Providers))
+	for i := range snapshot.Providers {
+		provider := snapshot.Providers[i]
+		configured[provider.Name] = true
+		copyProvider := provider
+		state.providerChoices = append(state.providerChoices, configProviderChoice{
+			label: "编辑 " + provider.Name, existing: &copyProvider,
+		})
+	}
+	for _, presetValue := range bootstrap.ProviderPresets() {
+		if configured[presetValue.Name] && !presetValue.NeedType {
+			continue
+		}
+		preset := presetValue
+		choice := configProviderChoice{label: "新增 " + preset.Label, preset: &preset}
+		if preset.NeedType {
+			choice.custom = true
+		}
+		state.providerChoices = append(state.providerChoices, choice)
+	}
+	return state
+}
+
+func (s *modelConfigState) selectProvider() {
+	if s.cursor < 0 || s.cursor >= len(s.providerChoices) {
+		return
+	}
+	choice := s.providerChoices[s.cursor]
+	s.cursor = 0
+	s.message = ""
+	if choice.existing != nil {
+		provider := choice.existing
+		s.provider = provider.Name
+		s.providerType = provider.Type
+		s.api = provider.API
+		s.baseURL = provider.BaseURL
+		s.models = append([]bootstrap.ModelConfig(nil), provider.Models...)
+		s.existing = true
+		s.hasAPIKey = provider.HasAPIKey
+		s.apiKeyOptional = !provider.RequiresAPIKey
+		if s.snapshot.DefaultProvider == s.provider {
+			s.defaultModel = s.snapshot.DefaultModel
+		}
+		if s.defaultModel == "" && len(s.models) > 0 {
+			s.defaultModel = s.models[0].Name
+		}
+		if s.providerType != "" {
+			s.step = configStepProtocol
+			s.cursor = protocolIndex(s.providerType)
+			return
+		}
+		s.afterProtocol()
+		return
+	}
+
+	s.existing = false
+	s.hasAPIKey = false
+	s.apiKeyAction = host.APIKeyReplace
+	if choice.custom {
+		s.apiKeyOptional = true
+		s.step = configStepCustomName
+		s.input = ""
+		return
+	}
+	s.provider = choice.preset.Name
+	s.baseURL = choice.preset.BaseURL
+	s.apiKeyOptional = choice.preset.APIKeyOptional
+	s.afterProtocol()
+}
+
+func (s *modelConfigState) afterProtocol() {
+	if s.providerType == "openai" || (s.providerType == "" && s.provider == "openai") {
+		s.step = configStepAPI
+		if s.api == "responses" {
+			s.cursor = 1
+		} else {
+			s.cursor = 0
+		}
+		return
+	}
+	s.beginAPIKey()
+}
+
+func (s *modelConfigState) beginAPIKey() {
+	s.cursor = 0
+	if s.existing && s.hasAPIKey {
+		s.step = configStepKeyAction
+		s.apiKeyAction = host.APIKeyKeep
+		return
+	}
+	s.step = configStepKeyInput
+	s.input = ""
+	s.apiKeyAction = host.APIKeyReplace
+}
+
+func (s *modelConfigState) beginBaseURL() {
+	s.step = configStepBaseURL
+	s.input = s.baseURL
+	s.cursor = 0
+}
+
+func (s *modelConfigState) beginTargets() bool {
+	if len(s.models) == 0 || s.defaultModel == "" {
+		s.message = "请至少添加一个模型并选择默认模型"
+		return false
+	}
+	s.step = configStepTarget
+	s.cursor = 0
+	s.targetIdx = 0
+	for i, target := range s.snapshot.Targets {
+		if target.Exists {
+			s.targetIdx = i
+			break
+		}
+	}
+	s.cursor = s.targetIdx
+	s.message = ""
+	return true
+}
+
+func (s *modelConfigState) selectedTarget() (bootstrap.ConfigTarget, bool) {
+	if s.cursor < 0 || s.cursor >= len(s.snapshot.Targets) {
+		return bootstrap.ConfigTarget{}, false
+	}
+	return s.snapshot.Targets[s.cursor], true
+}
+
+func (s *modelConfigState) targetWarning() string {
+	target, ok := s.selectedTarget()
+	if !ok {
+		return ""
+	}
+	for _, candidate := range s.snapshot.Targets {
+		if candidate.Exists && candidate.Precedence > target.Precedence {
+			return "警告：重启时可能被更高优先级的 " + candidate.Label + " 覆盖"
+		}
+	}
+	return ""
+}
+
+func (s *modelConfigState) deleteSelectedModel() {
+	if s.cursor < 0 || s.cursor >= len(s.models) {
+		return
+	}
+	model := s.models[s.cursor]
+	if model.Name == s.defaultModel {
+		s.message = "请先用 Enter 选择另一个默认模型"
+		return
+	}
+	for _, ref := range s.snapshot.ReferencesFor(s.provider, model.Name) {
+		if ref == "default" {
+			continue
+		}
+		s.message = fmt.Sprintf("模型仍被 %s 引用，不能删除", ref)
+		return
+	}
+	s.models = append(s.models[:s.cursor], s.models[s.cursor+1:]...)
+	if s.cursor >= len(s.models) && s.cursor > 0 {
+		s.cursor--
+	}
+	s.message = ""
+}
+
+func (s *modelConfigState) draft(targetID string) host.ModelConfigurationDraft {
+	return host.ModelConfigurationDraft{
+		Provider: s.provider, Type: s.providerType, API: s.api, BaseURL: s.baseURL,
+		Models: append([]bootstrap.ModelConfig(nil), s.models...), DefaultModel: s.defaultModel,
+		APIKeyAction: s.apiKeyAction, APIKey: s.apiKey, TargetID: targetID,
+	}
+}
+
+type modelConfigSavedMsg struct{ err error }
+
+func saveModelConfiguration(rt *host.Host, draft host.ModelConfigurationDraft) tea.Cmd {
+	return func() tea.Msg { return modelConfigSavedMsg{err: rt.ConfigureModels(draft)} }
+}
+
+func (m Model) handleModelConfigKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	state := m.modelConfig
+	if state == nil {
+		return m, nil
+	}
+	if msg.Type == tea.KeyEsc {
+		m.modelConfig = nil
+		return m, m.textarea.Focus()
+	}
+	if state.saving {
+		return m, nil
+	}
+
+	switch state.step {
+	case configStepProvider:
+		moveConfigCursor(state, msg, len(state.providerChoices))
+		if msg.Type == tea.KeyEnter {
+			state.selectProvider()
+		}
+	case configStepCustomName:
+		if handleConfigInput(&state.input, msg) && msg.Type == tea.KeyEnter {
+			name := strings.TrimSpace(state.input)
+			if name == "" {
+				state.message = "Provider 名称不能为空"
+				break
+			}
+			for _, provider := range state.snapshot.Providers {
+				if provider.Name == name {
+					state.message = "Provider 已存在，请返回后选择编辑"
+					return m, nil
+				}
+			}
+			state.provider = name
+			state.step = configStepProtocol
+			state.cursor = 0
+			state.message = ""
+		}
+	case configStepProtocol:
+		moveConfigCursor(state, msg, len(configProtocols))
+		if msg.Type == tea.KeyEnter {
+			state.providerType = configProtocols[state.cursor]
+			if state.providerType != "openai" {
+				state.api = ""
+			}
+			state.afterProtocol()
+		}
+	case configStepAPI:
+		moveConfigCursor(state, msg, len(configAPIs))
+		if msg.Type == tea.KeyEnter {
+			state.api = configAPIs[state.cursor]
+			state.beginAPIKey()
+		}
+	case configStepKeyAction:
+		moveConfigCursor(state, msg, len(configKeyActions))
+		if msg.Type == tea.KeyEnter {
+			state.apiKeyAction = configKeyActions[state.cursor].action
+			if state.apiKeyAction == host.APIKeyClear && !state.apiKeyOptional {
+				state.message = "该 Provider 必须配置 API Key，不能清除"
+				return m, nil
+			}
+			if state.apiKeyAction == host.APIKeyReplace {
+				state.step = configStepKeyInput
+				state.input = ""
+			} else {
+				state.beginBaseURL()
+			}
+		}
+	case configStepKeyInput:
+		if handleConfigInput(&state.input, msg) && msg.Type == tea.KeyEnter {
+			state.apiKey = strings.TrimSpace(state.input)
+			if state.apiKey == "" && !state.apiKeyOptional {
+				state.message = "该 Provider 必须配置 API Key"
+				return m, nil
+			}
+			state.beginBaseURL()
+		}
+	case configStepBaseURL:
+		if handleConfigInput(&state.input, msg) && msg.Type == tea.KeyEnter {
+			state.baseURL = strings.TrimSpace(state.input)
+			state.step = configStepModels
+			state.cursor = 0
+			state.message = ""
+		}
+	case configStepModels:
+		moveConfigCursor(state, msg, len(state.models))
+		switch strings.ToLower(msg.String()) {
+		case "a":
+			state.step = configStepModelName
+			state.input = ""
+			state.editModelIdx = -1
+			state.message = ""
+		case "e":
+			if len(state.models) > 0 {
+				state.editModelIdx = state.cursor
+				state.pendingModel = state.models[state.cursor].Name
+				if window := state.models[state.cursor].ContextWindow; window > 0 {
+					state.input = strconv.Itoa(window)
+				} else {
+					state.input = ""
+				}
+				state.step = configStepModelWindow
+			}
+		case "d":
+			state.deleteSelectedModel()
+		case "s", "ctrl+s":
+			state.beginTargets()
+		default:
+			if msg.Type == tea.KeyEnter && len(state.models) > 0 {
+				state.defaultModel = state.models[state.cursor].Name
+				state.message = "已选择默认模型：" + state.defaultModel
+			}
+		}
+	case configStepModelName:
+		if handleConfigInput(&state.input, msg) && msg.Type == tea.KeyEnter {
+			name := strings.TrimSpace(state.input)
+			if name == "" {
+				state.message = "模型名称不能为空"
+				break
+			}
+			for _, model := range state.models {
+				if model.Name == name {
+					state.message = "模型已存在"
+					return m, nil
+				}
+			}
+			state.pendingModel = name
+			state.input = ""
+			state.step = configStepModelWindow
+			state.message = ""
+		}
+	case configStepModelWindow:
+		if handleConfigInput(&state.input, msg) && msg.Type == tea.KeyEnter {
+			window, err := parseContextWindowInput(state.input)
+			if err != nil {
+				state.message = err.Error()
+				break
+			}
+			if state.editModelIdx >= 0 {
+				state.models[state.editModelIdx].ContextWindow = window
+				state.cursor = state.editModelIdx
+			} else {
+				state.models = append(state.models, bootstrap.ModelConfig{Name: state.pendingModel, ContextWindow: window})
+				state.cursor = len(state.models) - 1
+				if state.defaultModel == "" {
+					state.defaultModel = state.pendingModel
+				}
+			}
+			state.step = configStepModels
+			state.editModelIdx = -1
+			state.pendingModel = ""
+			state.message = ""
+		}
+	case configStepTarget:
+		moveConfigCursor(state, msg, len(state.snapshot.Targets))
+		if msg.Type == tea.KeyEnter {
+			target, ok := state.selectedTarget()
+			if !ok {
+				state.message = "没有可用的配置保存位置"
+				break
+			}
+			state.saving = true
+			state.message = "正在校验并保存配置..."
+			return m, saveModelConfiguration(m.runtime, state.draft(target.ID))
+		}
+	}
+	return m, nil
+}
+
+var configProtocols = []string{"openai", "anthropic", "gemini"}
+var configAPIs = []string{"chat", "responses"}
+
+var configKeyActions = []struct {
+	label  string
+	action host.APIKeyAction
+}{
+	{"保留现有 API Key", host.APIKeyKeep},
+	{"输入新的 API Key", host.APIKeyReplace},
+	{"清除 API Key", host.APIKeyClear},
+}
+
+func protocolIndex(protocol string) int {
+	for i, item := range configProtocols {
+		if item == protocol {
+			return i
+		}
+	}
+	return 0
+}
+
+func moveConfigCursor(state *modelConfigState, msg tea.KeyMsg, total int) {
+	if total <= 0 {
+		state.cursor = 0
+		return
+	}
+	switch msg.Type {
+	case tea.KeyUp:
+		state.cursor = (state.cursor - 1 + total) % total
+	case tea.KeyDown:
+		state.cursor = (state.cursor + 1) % total
+	}
+}
+
+// handleConfigInput 更新单行输入；返回 true 表示该键已被输入控件消费。
+func handleConfigInput(value *string, msg tea.KeyMsg) bool {
+	if msg.String() == "ctrl+u" {
+		*value = ""
+		return true
+	}
+	switch msg.Type {
+	case tea.KeyEnter:
+		return true
+	case tea.KeyBackspace, tea.KeyDelete:
+		runes := []rune(*value)
+		if len(runes) > 0 {
+			*value = string(runes[:len(runes)-1])
+		}
+		return true
+	case tea.KeySpace:
+		*value += " "
+		return true
+	case tea.KeyRunes:
+		*value += utils.CleanInputRunes(msg.Runes)
+		return true
+	default:
+		return false
+	}
+}
+
+func parseContextWindowInput(input string) (int, error) {
+	value := strings.ToLower(strings.TrimSpace(input))
+	if value == "" || value == "0" || value == "auto" {
+		return 0, nil
+	}
+	multiplier := float64(1)
+	if strings.HasSuffix(value, "k") {
+		multiplier = 1000
+		value = strings.TrimSpace(strings.TrimSuffix(value, "k"))
+	} else if strings.HasSuffix(value, "m") {
+		multiplier = 1_000_000
+		value = strings.TrimSpace(strings.TrimSuffix(value, "m"))
+	}
+	number, err := strconv.ParseFloat(value, 64)
+	if err != nil || number <= 0 {
+		return 0, fmt.Errorf("上下文窗口请输入正整数、128K、1M，或留空使用自动值")
+	}
+	result := number * multiplier
+	if result > float64(math.MaxInt) || math.Trunc(result) != result {
+		return 0, fmt.Errorf("上下文窗口超出有效整数范围")
+	}
+	return int(result), nil
+}
+
+func renderModelConfigModal(width, height int, state *modelConfigState) string {
+	if state == nil {
+		return ""
+	}
+	boxW := min(max(72, width*3/4), width-4)
+	boxH := min(max(20, height*3/4), height-2)
+	contentW := paddedModalContentWidth(boxW)
+	var lines []string
+	title := "/config 配置模型"
+	hint := "↑↓ 选择 · Enter 确认 · Esc 取消"
+
+	switch state.step {
+	case configStepProvider:
+		lines = append(lines, configHeading("选择要编辑或新增的 Provider"))
+		lines = append(lines, renderConfigChoices(labelsForProviderChoices(state.providerChoices), state.cursor, contentW, 12)...)
+	case configStepCustomName:
+		lines = append(lines, configHeading("自定义 Provider 名称"), renderConfigInput(state.input, false, contentW))
+		hint = configInputHint
+	case configStepProtocol:
+		lines = append(lines, configHeading("API 协议类型"))
+		lines = append(lines, renderConfigChoices(configProtocols, state.cursor, contentW, 8)...)
+	case configStepAPI:
+		lines = append(lines, configHeading("OpenAI Endpoint"))
+		lines = append(lines, renderConfigChoices([]string{"chat · /v1/chat/completions", "responses · /v1/responses"}, state.cursor, contentW, 8)...)
+	case configStepKeyAction:
+		lines = append(lines, configHeading("API Key"))
+		var labels []string
+		for _, item := range configKeyActions {
+			labels = append(labels, item.label)
+		}
+		lines = append(lines, renderConfigChoices(labels, state.cursor, contentW, 8)...)
+	case configStepKeyInput:
+		label := "输入 API Key（内容已隐藏）"
+		if state.apiKeyOptional {
+			label += "，可留空"
+		}
+		lines = append(lines, configHeading(label), renderConfigInput(state.input, true, contentW))
+		hint = configInputHint
+	case configStepBaseURL:
+		lines = append(lines, configHeading("Base URL（留空使用 Provider 默认地址）"), renderConfigInput(state.input, false, contentW))
+		hint = configInputHint
+	case configStepModels:
+		lines = append(lines, configHeading("管理模型列表"))
+		if len(state.models) == 0 {
+			lines = append(lines, lipgloss.NewStyle().Foreground(colorDim).Render("  尚未添加模型，按 A 添加"))
+		} else {
+			start, end := configWindow(len(state.models), state.cursor, 10)
+			for i := start; i < end; i++ {
+				model := state.models[i]
+				prefix := "  "
+				if i == state.cursor {
+					prefix = lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render("› ")
+				}
+				marker := "  "
+				if model.Name == state.defaultModel {
+					marker = "★ "
+				}
+				window := "自动"
+				if model.ContextWindow > 0 {
+					window = formatContextWindow(model.ContextWindow)
+				}
+				line := fmt.Sprintf("%s%s%-36s  上下文 %s", prefix, marker, truncateWidth(model.Name, 34), window)
+				lines = append(lines, truncateWidth(line, contentW))
+			}
+		}
+		hint = "↑↓ 选择 · Enter 设为默认 · A 新增 · E 编辑窗口 · D 删除 · S 保存 · Esc 取消"
+	case configStepModelName:
+		lines = append(lines, configHeading("新增模型名称"), renderConfigInput(state.input, false, contentW))
+		hint = configInputHint
+	case configStepModelWindow:
+		lines = append(lines, configHeading("模型 "+state.pendingModel+" 的上下文窗口"))
+		lines = append(lines, lipgloss.NewStyle().Foreground(colorDim).Render("留空或 0 = 自动解析；支持 128K / 1M"))
+		lines = append(lines, renderConfigInput(state.input, false, contentW))
+		hint = configInputHint
+	case configStepTarget:
+		lines = append(lines, configHeading("选择配置保存位置"))
+		var labels []string
+		for _, target := range state.snapshot.Targets {
+			exists := "新建"
+			if target.Exists {
+				exists = "已有"
+			}
+			labels = append(labels, fmt.Sprintf("%s · %s · %s", target.Label, exists, target.Path))
+		}
+		lines = append(lines, renderConfigChoices(labels, state.cursor, contentW, 8)...)
+		if warning := state.targetWarning(); warning != "" {
+			lines = append(lines, lipgloss.NewStyle().Foreground(colorReview).Render(truncateWidth(warning, contentW)))
+		}
+	}
+
+	if state.message != "" {
+		color := colorError
+		if state.saving || strings.HasPrefix(state.message, "已选择") {
+			color = colorAccent
+		}
+		lines = append(lines, "", lipgloss.NewStyle().Foreground(color).Render(truncateWidth(state.message, contentW)))
+	}
+	modal := renderPaddedModalFrame(boxW, boxH, title, hint, lines)
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, modal)
+}
+
+const configInputHint = "输入 · Enter 确认 · Ctrl+U 清空 · Esc 取消"
+
+func configHeading(text string) string {
+	return lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render(text)
+}
+
+func labelsForProviderChoices(choices []configProviderChoice) []string {
+	out := make([]string, 0, len(choices))
+	for _, choice := range choices {
+		out = append(out, choice.label)
+	}
+	return out
+}
+
+func renderConfigChoices(labels []string, cursor, width, limit int) []string {
+	if len(labels) == 0 {
+		return []string{lipgloss.NewStyle().Foreground(colorDim).Render("没有可用选项")}
+	}
+	start, end := configWindow(len(labels), cursor, limit)
+	lines := make([]string, 0, end-start)
+	for i := start; i < end; i++ {
+		prefix := "  "
+		style := lipgloss.NewStyle().Foreground(bodyTextColor)
+		if i == cursor {
+			prefix = "› "
+			style = style.Foreground(colorAccent).Bold(true)
+		}
+		lines = append(lines, prefix+style.Render(truncateWidth(labels[i], max(8, width-2))))
+	}
+	return lines
+}
+
+func configWindow(total, cursor, limit int) (int, int) {
+	if total <= limit {
+		return 0, total
+	}
+	start := max(0, cursor-limit/2)
+	end := min(total, start+limit)
+	if end-start < limit {
+		start = max(0, end-limit)
+	}
+	return start, end
+}
+
+func renderConfigInput(value string, secret bool, width int) string {
+	display := value
+	if secret {
+		display = strings.Repeat("•", utf8.RuneCountInString(value))
+	}
+	if display == "" {
+		display = "▌"
+	} else {
+		display += "▌"
+	}
+	return lipgloss.NewStyle().
+		Width(max(20, width-4)).
+		Border(baseBorder).
+		BorderForeground(colorDim).
+		Padding(0, 1).
+		Foreground(bodyTextColor).
+		Render(truncateWidth(display, max(16, width-8)))
+}

--- a/internal/entry/tui/command_config_test.go
+++ b/internal/entry/tui/command_config_test.go
@@ -1,0 +1,51 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/voocel/ainovel-cli/internal/host"
+)
+
+func TestParseContextWindowInput(t *testing.T) {
+	cases := map[string]int{
+		"": 0, "0": 0, "auto": 0, "128K": 128000, "1M": 1000000,
+		"1.5m": 1500000, "200000": 200000,
+	}
+	for input, want := range cases {
+		got, err := parseContextWindowInput(input)
+		if err != nil || got != want {
+			t.Errorf("parseContextWindowInput(%q) = %d, %v; want %d", input, got, err, want)
+		}
+	}
+	for _, input := range []string{"-1", "abc", "0.5"} {
+		if _, err := parseContextWindowInput(input); err == nil {
+			t.Errorf("parseContextWindowInput(%q) should fail", input)
+		}
+	}
+}
+
+func TestModelConfigModalDoesNotRenderAPIKey(t *testing.T) {
+	state := &modelConfigState{step: configStepKeyInput, input: "sk-super-secret"}
+	view := renderModelConfigModal(120, 40, state)
+	if strings.Contains(view, "sk-super-secret") {
+		t.Fatal("API key leaked into rendered modal")
+	}
+}
+
+func TestConfigCommandIsRegistered(t *testing.T) {
+	spec, ok := commandRegistryInstance().Find("config")
+	if !ok {
+		t.Fatal("/config is not registered")
+	}
+	if spec.Usage != "/config" || !spec.AutoExecute {
+		t.Fatalf("config spec = %#v", spec)
+	}
+}
+
+func TestModelSwitchLabelIncludesContextWindow(t *testing.T) {
+	state := modelSwitchState{models: []host.ConfiguredModel{{Name: "gpt-test", ContextWindow: 400000}}}
+	if got := state.modelLabel(); got != "gpt-test · 400K" {
+		t.Fatalf("modelLabel = %q", got)
+	}
+}

--- a/internal/entry/tui/command_model.go
+++ b/internal/entry/tui/command_model.go
@@ -7,11 +7,12 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/voocel/agentcore"
+	"github.com/voocel/ainovel-cli/internal/host"
 )
 
 type modelRuntime interface {
 	ConfiguredProviders() []string
-	ConfiguredModels(provider string) []string
+	ConfiguredModelOptions(provider string) []host.ConfiguredModel
 	CurrentModelSelection(role string) (string, string, bool)
 	AvailableThinking(role string) []agentcore.ThinkingLevel
 	CurrentThinking(role string) string
@@ -91,7 +92,7 @@ type modelSwitchState struct {
 	modelIdx    int
 	thinkingIdx int
 	providers   []string
-	models      []string
+	models      []host.ConfiguredModel
 	thinking    []thinkingOption
 	message     string
 }
@@ -145,7 +146,18 @@ func (s *modelSwitchState) model() string {
 	if len(s.models) == 0 || s.modelIdx < 0 || s.modelIdx >= len(s.models) {
 		return ""
 	}
-	return s.models[s.modelIdx]
+	return s.models[s.modelIdx].Name
+}
+
+func (s *modelSwitchState) modelLabel() string {
+	if len(s.models) == 0 || s.modelIdx < 0 || s.modelIdx >= len(s.models) {
+		return ""
+	}
+	model := s.models[s.modelIdx]
+	if window := formatContextWindow(model.ContextWindow); window != "" {
+		return model.Name + " · " + window
+	}
+	return model.Name
 }
 
 func (s *modelSwitchState) thinkingKey() string {
@@ -212,14 +224,14 @@ func (s *modelSwitchState) syncSelection(rt modelRuntime) {
 }
 
 func (s *modelSwitchState) syncModels(rt modelRuntime, preferred string) {
-	s.models = rt.ConfiguredModels(s.provider())
+	s.models = rt.ConfiguredModelOptions(s.provider())
 	s.modelIdx = 0
 	if len(s.models) == 0 {
 		return
 	}
 	preferred = strings.TrimSpace(preferred)
 	for i, model := range s.models {
-		if model == preferred {
+		if model.Name == preferred {
 			s.modelIdx = i
 			return
 		}
@@ -299,7 +311,7 @@ func renderModelSwitchBar(width int, state *modelSwitchState) string {
 
 	row1 := renderModelField("角色", state.roleLabel(), state.focus == modelFocusRole)
 	row2 := renderModelField("Provider", state.provider(), state.focus == modelFocusProvider)
-	row3 := renderModelField("模型", state.model(), state.focus == modelFocusModel)
+	row3 := renderModelField("模型", state.modelLabel(), state.focus == modelFocusModel)
 	row4 := renderModelField("推理强度", state.thinkingLabel(), state.focus == modelFocusThinking)
 	hint := lipgloss.NewStyle().
 		Foreground(colorDim).

--- a/internal/entry/tui/commands.go
+++ b/internal/entry/tui/commands.go
@@ -88,6 +88,23 @@ func commandRegistryInstance() commandRegistry {
 			},
 		},
 		{
+			Name:        "config",
+			Group:       "system",
+			Usage:       "/config",
+			Description: "新增或编辑 Provider、模型与上下文窗口",
+			AutoExecute: true,
+			Run: func(m Model, args []string) (tea.Model, tea.Cmd) {
+				if len(args) != 0 {
+					m.applyEvent(host.Event{Time: time.Now(), Category: "ERROR", Summary: "用法：/config", Level: "error"})
+					m.refreshEventViewport()
+					return m, nil
+				}
+				m.modelConfig = newModelConfigState(m.runtime)
+				m.textarea.Blur()
+				return m, nil
+			},
+		},
+		{
 			Name:        "diag",
 			Group:       "analysis",
 			Usage:       "/diag",

--- a/internal/entry/tui/model.go
+++ b/internal/entry/tui/model.go
@@ -59,6 +59,7 @@ type Model struct {
 	cocreate       *cocreateState
 	help           *helpState
 	modelSwitch    *modelSwitchState
+	modelConfig    *modelConfigState
 	report         *reportState
 	version        string
 	importer       *importState
@@ -617,6 +618,9 @@ func (m Model) View() string {
 	}
 	if m.cocreate != nil {
 		return renderCoCreateModal(m.width, m.height, m.cocreate, errorText(m.err), m.textarea.View(), m.spinnerIdx, m.quitPending)
+	}
+	if m.modelConfig != nil {
+		return renderModelConfigModal(m.width, m.height, m.modelConfig)
 	}
 	if m.help != nil {
 		return renderHelpModal(m.width, m.height, m.help)

--- a/internal/entry/tui/model_update.go
+++ b/internal/entry/tui/model_update.go
@@ -68,6 +68,8 @@ func (m Model) handleOverlayKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 		return m.handleBlockingModalKey(msg, m.handleAskUserKey)
 	case m.cocreate != nil:
 		return m.handleBlockingModalKey(msg, m.handleCoCreateKey)
+	case m.modelConfig != nil:
+		return m.handleBlockingModalKey(msg, m.handleModelConfigKey)
 	case m.help != nil:
 		return m.handleBlockingModalKey(msg, m.handleHelpKey)
 	case m.modelSwitch != nil:
@@ -382,7 +384,7 @@ func (m Model) handleMouseMsg(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, cmd
 	}
-	if m.modelSwitch != nil || m.askState != nil {
+	if m.modelSwitch != nil || m.modelConfig != nil || m.askState != nil {
 		return m, nil
 	}
 	if pane, ok := m.paneAtMouse(msg.X, msg.Y); ok {
@@ -529,6 +531,17 @@ func (m Model) handleRuntimeMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		}
 		m.refreshEventViewport()
 		return m, nil, true
+	case modelConfigSavedMsg:
+		if m.modelConfig == nil {
+			return m, nil, true
+		}
+		if msg.err != nil {
+			m.modelConfig.saving = false
+			m.modelConfig.message = msg.err.Error()
+			return m, nil, true
+		}
+		m.modelConfig = nil
+		return m, tea.Batch(fetchSnapshot(m.runtime), m.textarea.Focus()), true
 	case startResultMsg:
 		next, cmd := m.handleStartResultMsg(msg)
 		return next, cmd, true

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -49,6 +49,7 @@ type Host struct {
 	budget          *BudgetSentinel     // 预算政策；未启用为 nil（方法 nil 安全）
 	gate            *ChapterAdvanceGate // 章节许可与一次性暂停的统一政策组件
 	notifier        *notify.Notifier    // 无人值守告警；未启用为 nil（Send nil 安全）
+	configTargets   []bootstrap.ConfigTarget
 
 	events   chan Event
 	streamCh chan string
@@ -76,8 +77,17 @@ const (
 	lifecycleCompleted lifecycle = "completed"
 )
 
-// New 创建 Host。
+type Options struct {
+	ConfigPath string
+}
+
+// New 创建使用默认配置目标的 Host。
 func New(cfg bootstrap.Config, bundle assets.Bundle) (*Host, error) {
+	return NewWithOptions(cfg, bundle, Options{})
+}
+
+// NewWithOptions 创建 Host，并保留启动时的配置来源供 TUI /config 选择写入目标。
+func NewWithOptions(cfg bootstrap.Config, bundle assets.Bundle, opts Options) (*Host, error) {
 	cfg.FillDefaults()
 	if err := cfg.ValidateBase(); err != nil {
 		return nil, err
@@ -147,6 +157,7 @@ func New(cfg bootstrap.Config, bundle assets.Bundle) (*Host, error) {
 		userRules:       userrules.NewService(store, models.Default, rules.DefaultOptions()),
 		usage:           usage,
 		usageCancel:     usageCancel,
+		configTargets:   bootstrap.ConfigTargets(opts.ConfigPath),
 		events:          make(chan Event, 100),
 		streamCh:        make(chan string, 256),
 		done:            make(chan struct{}, 4),
@@ -865,10 +876,12 @@ func (h *Host) Snapshot() UISnapshot {
 	h.mu.Lock()
 	state := h.lifecycle
 	provider, model, _ := h.models.CurrentSelection("default")
+	modelWindow, _ := h.cfg.ResolveContextWindow(provider, model)
+	thinkingLevel := h.cfg.ResolveReasoningEffort("default")
+	style := h.cfg.Style
 	h.mu.Unlock()
 
-	// 动态解析当前模型的上下文窗口，/model 切换后下一次 Snapshot 自动反映
-	modelWindow, _ := h.cfg.ResolveContextWindow(model)
+	// 动态解析当前模型的上下文窗口，/model 或 /config 切换后下一次 Snapshot 自动反映。
 	cost, tokIn, tokOut, cacheRead, cacheWrite := h.usage.Totals()
 	saved := h.usage.SavedUSD()
 	overallCapable := h.usage.OverallCacheCapable()
@@ -909,8 +922,8 @@ func (h *Host) Snapshot() UISnapshot {
 		Provider:               provider,
 		ModelName:              model,
 		ModelContextWindow:     modelWindow,
-		ThinkingLevel:          h.cfg.ResolveReasoningEffort("default"),
-		Style:                  h.cfg.Style,
+		ThinkingLevel:          thinkingLevel,
+		Style:                  style,
 		RuntimeState:           string(state),
 		IsRunning:              state == lifecycleRunning,
 		TotalInputTokens:       tokIn,
@@ -1129,7 +1142,7 @@ func (h *Host) SwitchModel(role, provider, model string) error {
 	if logRole == "" {
 		logRole = "default"
 	}
-	window, source := h.cfg.ResolveContextWindow(model)
+	window, source := h.cfg.ResolveContextWindow(provider, model)
 	bootstrap.LogContextWindowChoice(logRole, model, window, source)
 
 	// 无常驻上下文需要联动:writer/architect/editor 的 ContextManager 走

--- a/internal/host/model_config.go
+++ b/internal/host/model_config.go
@@ -1,0 +1,253 @@
+package host
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/voocel/ainovel-cli/internal/bootstrap"
+)
+
+type APIKeyAction string
+
+const (
+	APIKeyKeep    APIKeyAction = "keep"
+	APIKeyReplace APIKeyAction = "replace"
+	APIKeyClear   APIKeyAction = "clear"
+)
+
+// ProviderSnapshot 是供 TUI 使用的脱敏 provider 配置。
+type ProviderSnapshot struct {
+	Name           string
+	Type           string
+	API            string
+	BaseURL        string
+	Models         []bootstrap.ModelConfig
+	HasAPIKey      bool
+	RequiresAPIKey bool
+}
+
+type ModelConfigurationSnapshot struct {
+	Providers       []ProviderSnapshot
+	DefaultProvider string
+	DefaultModel    string
+	Targets         []bootstrap.ConfigTarget
+	References      map[string][]string
+}
+
+func (s ModelConfigurationSnapshot) ReferencesFor(provider, model string) []string {
+	return append([]string(nil), s.References[modelReferenceKey(provider, model)]...)
+}
+
+// ModelConfigurationDraft 是 /config 提交给 Host 的完整模型配置草稿。
+type ModelConfigurationDraft struct {
+	Provider     string
+	Type         string
+	API          string
+	BaseURL      string
+	Models       []bootstrap.ModelConfig
+	DefaultModel string
+	APIKeyAction APIKeyAction
+	APIKey       string
+	TargetID     string
+}
+
+type ConfiguredModel struct {
+	Name          string
+	ContextWindow int
+	ContextSource bootstrap.ContextWindowSource
+}
+
+func modelReferenceKey(provider, model string) string {
+	return strings.TrimSpace(provider) + "\x00" + strings.TrimSpace(model)
+}
+
+// ModelConfiguration 返回脱敏配置、可写目标和模型引用，绝不暴露现有 API Key。
+func (h *Host) ModelConfiguration() ModelConfigurationSnapshot {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	providers := make([]ProviderSnapshot, 0, len(h.cfg.Providers))
+	for name, pc := range h.cfg.Providers {
+		configuredModels := make([]bootstrap.ModelConfig, 0)
+		for _, modelName := range h.cfg.CandidateModels(name) {
+			model, ok := pc.ModelConfig(modelName)
+			if !ok {
+				model = bootstrap.ModelConfig{Name: modelName}
+			}
+			configuredModels = append(configuredModels, model)
+		}
+		providers = append(providers, ProviderSnapshot{
+			Name: name, Type: pc.Type, API: pc.API, BaseURL: pc.BaseURL,
+			Models:    configuredModels,
+			HasAPIKey: pc.APIKey != "", RequiresAPIKey: pc.RequiresAPIKey(name),
+		})
+	}
+	sort.Slice(providers, func(i, j int) bool { return providers[i].Name < providers[j].Name })
+
+	refs := make(map[string][]string)
+	refs[modelReferenceKey(h.cfg.Provider, h.cfg.ModelName)] = append(
+		refs[modelReferenceKey(h.cfg.Provider, h.cfg.ModelName)], "default")
+	for role, rc := range h.cfg.Roles {
+		key := modelReferenceKey(rc.Provider, rc.Model)
+		refs[key] = append(refs[key], role)
+		for i, fallback := range rc.Fallbacks {
+			key = modelReferenceKey(fallback.Provider, fallback.Model)
+			refs[key] = append(refs[key], fmt.Sprintf("%s fallback[%d]", role, i))
+		}
+	}
+	for key := range refs {
+		sort.Strings(refs[key])
+	}
+
+	return ModelConfigurationSnapshot{
+		Providers: providers, DefaultProvider: h.cfg.Provider, DefaultModel: h.cfg.ModelName,
+		Targets: append([]bootstrap.ConfigTarget(nil), h.configTargets...), References: refs,
+	}
+}
+
+func (h *Host) ConfiguredModelOptions(provider string) []ConfiguredModel {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	names := h.cfg.CandidateModels(provider)
+	out := make([]ConfiguredModel, 0, len(names))
+	for _, name := range names {
+		window, source := h.cfg.ResolveContextWindow(provider, name)
+		out = append(out, ConfiguredModel{Name: name, ContextWindow: window, ContextSource: source})
+	}
+	return out
+}
+
+// ConfigureModels 校验、持久化并热应用一个 provider 的模型库。
+func (h *Host) ConfigureModels(draft ModelConfigurationDraft) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	draft.Provider = strings.TrimSpace(draft.Provider)
+	draft.Type = strings.ToLower(strings.TrimSpace(draft.Type))
+	draft.API = strings.ToLower(strings.TrimSpace(draft.API))
+	draft.BaseURL = strings.TrimSpace(draft.BaseURL)
+	draft.DefaultModel = strings.TrimSpace(draft.DefaultModel)
+	draft.APIKey = strings.TrimSpace(draft.APIKey)
+	if draft.Provider == "" || draft.DefaultModel == "" {
+		return fmt.Errorf("provider 和默认模型不能为空")
+	}
+
+	candidate := bootstrap.CloneConfig(h.cfg)
+	pc := candidate.Providers[draft.Provider]
+	oldModels := append([]bootstrap.ModelConfig(nil), pc.Models...)
+	pc.SetType(draft.Type)
+	pc.SetAPI(draft.API)
+	pc.SetBaseURL(draft.BaseURL)
+	configuredModels := make([]bootstrap.ModelConfig, 0, len(draft.Models))
+	defaultFound := false
+	seen := make(map[string]bool, len(draft.Models))
+	for _, model := range draft.Models {
+		model.Name = strings.TrimSpace(model.Name)
+		if model.Name == "" {
+			return fmt.Errorf("模型名称不能为空")
+		}
+		if model.ContextWindow < 0 {
+			return fmt.Errorf("模型 %q 的上下文窗口不能为负数", model.Name)
+		}
+		if seen[model.Name] {
+			return fmt.Errorf("模型 %q 重复", model.Name)
+		}
+		seen[model.Name] = true
+		defaultFound = defaultFound || model.Name == draft.DefaultModel
+		configuredModels = append(configuredModels, model)
+	}
+	pc.SetModels(configuredModels)
+	if !defaultFound {
+		return fmt.Errorf("默认模型 %q 必须保存在模型列表中", draft.DefaultModel)
+	}
+
+	switch draft.APIKeyAction {
+	case "", APIKeyKeep:
+		// 保留候选配置里的现有值；新增 provider 时自然为空。
+	case APIKeyReplace:
+		pc.SetAPIKey(draft.APIKey)
+	case APIKeyClear:
+		pc.SetAPIKey("")
+	default:
+		return fmt.Errorf("未知 API Key 操作 %q", draft.APIKeyAction)
+	}
+
+	newNames := make(map[string]bool, len(pc.Models))
+	for _, model := range pc.Models {
+		newNames[model.Name] = true
+	}
+	for _, old := range oldModels {
+		if newNames[old.Name] {
+			continue
+		}
+		for _, ref := range h.modelReferencesLocked(draft.Provider, old.Name) {
+			if ref == "default" {
+				continue // 本次提交会把 default 原子切到 draft.DefaultModel。
+			}
+			return fmt.Errorf("模型 %q 仍被 %s 引用，不能删除", old.Name, ref)
+		}
+	}
+
+	if candidate.Providers == nil {
+		candidate.Providers = make(map[string]bootstrap.ProviderConfig)
+	}
+	candidate.Providers[draft.Provider] = pc
+	candidate.Provider = draft.Provider
+	candidate.ModelName = draft.DefaultModel
+	if err := candidate.ValidateBase(); err != nil {
+		return err
+	}
+	prepared, err := bootstrap.NewModelSet(candidate)
+	if err != nil {
+		return fmt.Errorf("创建模型客户端失败: %w", err)
+	}
+
+	var target bootstrap.ConfigTarget
+	foundTarget := false
+	for _, item := range h.configTargets {
+		if item.ID == draft.TargetID {
+			target = item
+			foundTarget = true
+			break
+		}
+	}
+	if !foundTarget {
+		return fmt.Errorf("未知配置保存目标 %q", draft.TargetID)
+	}
+	if err := bootstrap.SaveModelConfig(target.Path, draft.Provider, pc, draft.DefaultModel); err != nil {
+		return fmt.Errorf("保存配置失败: %w", err)
+	}
+
+	h.models.ApplyPrepared(prepared)
+	h.cfg = candidate
+	h.normalizeThinkingLocked("default")
+	h.applyThinkingLocked("default")
+	window, source := h.cfg.ResolveContextWindow(draft.Provider, draft.DefaultModel)
+	bootstrap.LogContextWindowChoice("default", draft.DefaultModel, window, source)
+	h.emitEvent(Event{
+		Time: time.Now(), Category: "SYSTEM", Level: "info",
+		Summary: fmt.Sprintf("模型配置已保存：%s/%s → %s", draft.Provider, draft.DefaultModel, target.Path),
+	})
+	return nil
+}
+
+func (h *Host) modelReferencesLocked(provider, model string) []string {
+	var refs []string
+	if h.cfg.Provider == provider && h.cfg.ModelName == model {
+		refs = append(refs, "default")
+	}
+	for role, rc := range h.cfg.Roles {
+		if rc.Provider == provider && rc.Model == model {
+			refs = append(refs, role)
+		}
+		for i, fallback := range rc.Fallbacks {
+			if fallback.Provider == provider && fallback.Model == model {
+				refs = append(refs, fmt.Sprintf("%s fallback[%d]", role, i))
+			}
+		}
+	}
+	sort.Strings(refs)
+	return refs
+}

--- a/internal/host/model_config_test.go
+++ b/internal/host/model_config_test.go
@@ -1,0 +1,75 @@
+package host
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/voocel/ainovel-cli/internal/bootstrap"
+)
+
+func newModelConfigTestHost(t *testing.T) (*Host, string) {
+	t.Helper()
+	pc := bootstrap.ProviderConfig{
+		Type: "openai", APIKey: "old-secret", BaseURL: "https://example.com/v1",
+		Models: []bootstrap.ModelConfig{{Name: "old", ContextWindow: 128000}, {Name: "writer-model"}},
+	}
+	cfg := bootstrap.Config{
+		Provider: "proxy", ModelName: "old", Providers: map[string]bootstrap.ProviderConfig{"proxy": pc},
+		Roles: map[string]bootstrap.RoleConfig{"writer": {Provider: "proxy", Model: "writer-model"}},
+	}
+	models, err := bootstrap.NewModelSet(cfg)
+	if err != nil {
+		t.Fatalf("new model set: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "config.json")
+	return &Host{
+		cfg: cfg, models: models, events: make(chan Event, 4),
+		configTargets: []bootstrap.ConfigTarget{{ID: "test", Label: "test", Path: path}},
+	}, path
+}
+
+func TestConfigureModelsRejectsDeletingReferencedModel(t *testing.T) {
+	h, _ := newModelConfigTestHost(t)
+	err := h.ConfigureModels(ModelConfigurationDraft{
+		Provider: "proxy", Type: "openai", BaseURL: "https://example.com/v1",
+		Models: []bootstrap.ModelConfig{{Name: "new"}}, DefaultModel: "new",
+		APIKeyAction: APIKeyKeep, TargetID: "test",
+	})
+	if err == nil || !strings.Contains(err.Error(), "writer") {
+		t.Fatalf("expected writer reference error, got %v", err)
+	}
+	provider, model, _ := h.models.CurrentSelection("default")
+	if provider != "proxy" || model != "old" {
+		t.Fatalf("runtime mutated after failure: %s/%s", provider, model)
+	}
+}
+
+func TestConfigureModelsPersistsAndHotApplies(t *testing.T) {
+	h, path := newModelConfigTestHost(t)
+	err := h.ConfigureModels(ModelConfigurationDraft{
+		Provider: "proxy", Type: "openai", API: "responses", BaseURL: "https://new.example/v1",
+		Models:       []bootstrap.ModelConfig{{Name: "new", ContextWindow: 640000}, {Name: "writer-model"}},
+		DefaultModel: "new", APIKeyAction: APIKeyKeep, TargetID: "test",
+	})
+	if err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+	provider, model, _ := h.models.CurrentSelection("default")
+	if provider != "proxy" || model != "new" {
+		t.Fatalf("runtime selection = %s/%s", provider, model)
+	}
+	if window, source := h.models.ResolveContextWindow(provider, model); window != 640000 || source != bootstrap.CtxWindowModelConfig {
+		t.Fatalf("runtime window = %d %s", window, source)
+	}
+	saved, err := bootstrap.LoadConfigFile(path)
+	if err != nil {
+		t.Fatalf("load saved: %v", err)
+	}
+	if saved.Provider != "proxy" || saved.ModelName != "new" || saved.Providers["proxy"].APIKey != "old-secret" {
+		t.Fatalf("saved config = %#v", saved)
+	}
+	if len(saved.Providers["proxy"].Models) != 2 || saved.Providers["proxy"].Models[0].ContextWindow != 640000 {
+		t.Fatalf("saved models = %#v", saved.Providers["proxy"].Models)
+	}
+}


### PR DESCRIPTION
当前每个 Provider 的模型配置仅支持字符串列表，模型切换和上下文窗口配置不够方便。本 PR 新增 `/config` 交互式配置命令，支持保存多个模型及各自的上下文窗口，并在运行时立即生效。

## 主要改动

- 新增 `/config` 交互式配置命令
  - 支持已有、内置及自定义 Provider
  - 支持配置协议、API Endpoint、API Key 和 Base URL
  - API Key 使用隐藏输入，可选择保留、替换或清除
  - 按 `Esc` 可取消配置且不修改现有状态

- 新增多模型管理
  - 添加和删除模型
  - 编辑模型上下文窗口
  - 设置 Provider 默认模型
  - 删除仍被角色或 fallback 引用的模型时提供保护
  - 上下文窗口支持整数、`128K`、`1M` 等格式

- 升级模型配置格式
  - 新增 `ModelConfig`，支持模型级 `context_window`
  - 兼容旧版字符串模型数组
  - 经 `/config` 保存后统一规范化为对象列表

- 增强 `/model` 切换
  - 展示所有已保存模型
  - 保持配置文件中的模型顺序
  - 显示模型的有效上下文窗口，例如 `gpt-5.4 · 400K`

- 支持动态上下文窗口解析
  - 模型级配置
  - 旧版顶层 `context_window`
  - 内置或在线模型注册表
  - 默认 `200000`
  - 切换模型或保存配置后，下一轮 Writer 立即使用最新窗口

- 完善配置持久化
  - 支持全局、项目和 `--config` 三种保存目标
  - 补丁式更新配置，保留未编辑字段
  - 使用临时文件和 rename 原子写入
  - 配置文件权限设置为 `0600`
  - 写盘或客户端创建失败时保持当前运行状态不变

## 兼容性

- 继续支持旧格式：

  ```json
  "models": ["model-a", "model-b"]
  ```

- 新格式示例：

  ```json
  "models": [
    {
      "name": "gpt-5.4",
      "context_window": 400000
    },
    {
      "name": "gpt-5.4-mini"
    }
  ]
  ```

- 顶层 `context_window` 继续作为旧配置的全局回退。
- 模型级窗口仅用于本地上下文压缩判断，不修改远端 API 请求参数。