### PR TITLE
fix(windows): 通知测试在 PowerShell 下使用 UTF-8

### DIFF
--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -51,8 +51,13 @@ func TestCommandChannelEnvAndStdin(t *testing.T) {
 
 	command := `echo "$NOTIFY_KIND|$NOTIFY_LEVEL|$NOTIFY_TITLE|$NOTIFY_BODY" > ` + shellQuote(envFile) + ` && cat > ` + shellQuote(jsonFile)
 	if runtime.GOOS == "windows" {
-		command = `Set-Content -LiteralPath ` + powerShellQuote(envFile) + ` -Value "$env:NOTIFY_KIND|$env:NOTIFY_LEVEL|$env:NOTIFY_TITLE|$env:NOTIFY_BODY"; ` +
-			`[Console]::In.ReadToEnd() | Set-Content -LiteralPath ` + powerShellQuote(jsonFile) + ` -NoNewline`
+		// Explicit UTF-8 (no BOM) so Chinese title/body survive PowerShell's default code page.
+		command = `$utf8 = New-Object System.Text.UTF8Encoding $false; ` +
+			`$line = "$env:NOTIFY_KIND|$env:NOTIFY_LEVEL|$env:NOTIFY_TITLE|$env:NOTIFY_BODY"; ` +
+			`[System.IO.File]::WriteAllText(` + powerShellQuote(envFile) + `, $line, $utf8); ` +
+			`$reader = New-Object System.IO.StreamReader([Console]::OpenStandardInput(), $utf8); ` +
+			`$payload = $reader.ReadToEnd(); ` +
+			`[System.IO.File]::WriteAllText(` + powerShellQuote(jsonFile) + `, $payload, $utf8)`
 	}
 	n := New(command, nil)
 	nt := Notification{Kind: KindBudget, Level: "warn", Title: "ainovel: 预算", Body: "已花费 $8.00"}


### PR DESCRIPTION
## 摘要

让 notify 相关**单元测试**在 Windows 上稳定通过，不改动生产逻辑。

关联：#91

## 背景

在 Windows 上跑 `TestCommandChannelEnvAndStdin` 时，PowerShell 默认代码页可能导致中文 `Title`/`Body` 写入文件后乱码，测试误报失败。这是测试夹具问题，不是运行时通知实现 bug。

## 改动

- `internal/notify/notify_test.go`：Windows 分支改用显式 UTF-8（无 BOM）写入 env 行与 stdin payload

## 非目标

- 不改 `notify` 生产实现
- 不改 updater（上游 `main` 在 import-pipeline 后已对权限断言做了平台安全处理，本 PR 不再包含该文件）

## 测试计划

- [x] Windows：`go test ./internal/notify ./internal/version -count=1`