### PR TITLE
feat: 新增 skill 跨书经验库系统

### DIFF
--- a/assets/prompts/architect-long.md
+++ b/assets/prompts/architect-long.md
@@ -7,6 +7,8 @@
 - **save_foundation**: 保存基础设定。
 - **revise_outline**: 按用户要求修订尚未发生的目标弧大纲尾段。
 - **audit_foundation**: 对重新读取的已落盘基础设定做跨文件语义审查。
+- **search_skills**: 本地 skill 库检索。当需要题材套路、结构模板、风格预设、流派发展史、连载套路等可复用经验时，**优先**调用本工具。返回 top-N 本地 skill 的 name/description/category/tags/priority；命中后再调 `read_skill(name=...)` 读全文。零成本、零延迟、跨书复用。
+- **read_skill**: 读取本地 skill 全文（需先通过 `search_skills` 拿到 name）。
 
 ## 硬约束
 

--- a/assets/prompts/architect-short.md
+++ b/assets/prompts/architect-short.md
@@ -7,6 +7,8 @@
 - **save_foundation**: 保存基础设定
 - **revise_outline**: 按用户要求修订尚未发生的扁平大纲尾段
 - **audit_foundation**: 对重新读取的已落盘基础设定做跨文件语义审查
+- **search_skills**: 本地 skill 库检索。当需要题材套路、结构模板、风格预设、流派常识等可复用经验时，**优先**调用本工具。返回 top-N 本地 skill 的 name/description/category/tags/priority；命中后再调 `read_skill(name=...)` 读全文。零成本、零延迟、跨书复用。
+- **read_skill**: 读取本地 skill 全文（需先通过 `search_skills` 拿到 name）。
 
 ## 硬约束
 

--- a/cmd/ainovel-cli/main.go
+++ b/cmd/ainovel-cli/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/voocel/ainovel-cli/assets"
 	"github.com/voocel/ainovel-cli/internal/bootstrap"
+	"github.com/voocel/ainovel-cli/internal/cli"
 	"github.com/voocel/ainovel-cli/internal/entry/headless"
 	"github.com/voocel/ainovel-cli/internal/entry/startup"
 	"github.com/voocel/ainovel-cli/internal/entry/tui"
@@ -27,9 +28,14 @@ var (
 var headlessMode bool
 
 func main() {
-	// 子命令在常规 flag 解析之前拦截：eval 是离线评测 harness，参数体系独立。
-	if len(os.Args) > 1 && os.Args[1] == "eval" {
-		os.Exit(eval.Command(os.Args[2:]))
+	// 子命令在常规 flag 解析之前拦截：eval / skill 参数体系独立，不需要加载配置。
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "eval":
+			os.Exit(eval.Command(os.Args[2:]))
+		case "skill":
+			os.Exit(cli.SkillCommand(os.Args[2:]))
+		}
 	}
 
 	opts, args, err := parseCLIOptions(os.Args[1:])

--- a/internal/agents/build.go
+++ b/internal/agents/build.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"strings"
 
 	"github.com/voocel/agentcore"
@@ -16,6 +17,7 @@ import (
 	"github.com/voocel/ainovel-cli/internal/agents/ctxpack"
 	"github.com/voocel/ainovel-cli/internal/agents/guard"
 	"github.com/voocel/ainovel-cli/internal/bootstrap"
+	"github.com/voocel/ainovel-cli/internal/skills"
 	"github.com/voocel/ainovel-cli/internal/store"
 	"github.com/voocel/ainovel-cli/internal/tools"
 )
@@ -126,6 +128,19 @@ func BuildWorkers(
 		tools.NewReviseOutlineTool(store),
 		tools.NewResolveOutlineFeedbackTool(store),
 		tools.NewAuditFoundationTool(store),
+	}
+
+	// 跨书 skill 库。失败时不阻断主流程：skill 工具返回空结果，走模型自身知识。
+	skillStore := skills.NewStore(filepath.Join(bootstrap.DefaultConfigDir(), "skills"))
+	if err := skillStore.Refresh(); err != nil {
+		slog.Warn("skill 库初始化失败，本次禁用", "module", "agent", "err", err)
+		skillStore = nil
+	}
+	if skillStore != nil {
+		architectTools = append(architectTools,
+			tools.NewSkillSearchTool(skillStore),
+			tools.NewSkillReadTool(skillStore),
+		)
 	}
 	writerTools := []agentcore.Tool{
 		contextTool,

--- a/internal/cli/skill.go
+++ b/internal/cli/skill.go
@@ -1,0 +1,218 @@
+// Package cli 提供 ainovel 的辅助子命令（如 skill）。
+// 这些命令在 main.go 顶部拦截，不参与 TUI/headless 主流程。
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/voocel/ainovel-cli/internal/bootstrap"
+	"github.com/voocel/ainovel-cli/internal/skills"
+)
+
+// SkillCommand 处理 `ainovel skill ...` 子命令。
+func SkillCommand(args []string) int {
+	if len(args) == 0 {
+		printSkillUsage()
+		return 0
+	}
+
+	store := skills.NewStore(filepath.Join(bootstrap.DefaultConfigDir(), "skills"))
+	if err := store.Refresh(); err != nil {
+		fmt.Fprintf(os.Stderr, "skill 库初始化失败: %v\n", err)
+		return 1
+	}
+
+	switch args[0] {
+	case "list", "ls":
+		return runSkillList(store, args[1:])
+	case "show", "cat":
+		return runSkillShow(store, args[1:])
+	case "add":
+		return runSkillAdd(store, args[1:])
+	case "edit":
+		return runSkillEdit(store, args[1:])
+	case "remove", "rm", "delete":
+		return runSkillRemove(store, args[1:])
+	case "refresh", "reload":
+		return runSkillRefresh(store, args[1:])
+	case "-h", "--help", "help":
+		printSkillUsage()
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "未知子命令: %s\n", args[0])
+		printSkillUsage()
+		return 1
+	}
+}
+
+func printSkillUsage() {
+	fmt.Println("用法: ainovel skill <command> [args]")
+	fmt.Println("")
+	fmt.Println("命令:")
+	fmt.Println("  list [category]      列出所有 skill（或某分类下）")
+	fmt.Println("  show <name>          显示某 skill 全文")
+	fmt.Println("  add <file>           从 .md 文件添加 skill（含 frontmatter 校验）")
+	fmt.Println("  edit <name>          用 $EDITOR 编辑 skill")
+	fmt.Println("  remove <name>        删除 skill（带确认）")
+	fmt.Println("  refresh              强制刷新索引")
+	fmt.Println("")
+	fmt.Println("skill 存放位置: ~/.ainovel/skills/<category>/<name>.md")
+}
+
+func runSkillList(store *skills.Store, args []string) int {
+	category := ""
+	if len(args) > 0 {
+		category = strings.TrimSpace(args[0])
+	}
+	metas := store.List(category)
+	if len(metas) == 0 {
+		fmt.Println("本地 skill 库为空。")
+		return 0
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tCATEGORY\tPRIORITY\tDESCRIPTION")
+	for _, m := range metas {
+		fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", m.Name, m.Category, m.Priority, m.Description)
+	}
+	w.Flush()
+	return 0
+}
+
+func runSkillShow(store *skills.Store, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "用法: ainovel skill show <name>")
+		return 1
+	}
+	content, err := store.Read(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "读取失败: %v\n", err)
+		return 1
+	}
+	fmt.Println(content)
+	return 0
+}
+
+func runSkillAdd(store *skills.Store, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "用法: ainovel skill add <file.md>")
+		return 1
+	}
+	path := args[0]
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "读取文件失败: %v\n", err)
+		return 1
+	}
+	meta, body, err := skills.ParseSkill(path, string(raw))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "解析 skill 失败: %v\n", err)
+		return 1
+	}
+	if meta.Name == "" {
+		fmt.Fprintln(os.Stderr, "frontmatter 缺少 name 字段")
+		return 1
+	}
+	if meta.Description == "" {
+		fmt.Fprintln(os.Stderr, "frontmatter 缺少 description 字段")
+		return 1
+	}
+	if err := store.Add(meta, body); err != nil {
+		fmt.Fprintf(os.Stderr, "添加失败: %v\n", err)
+		return 1
+	}
+	fmt.Printf("已添加 skill: %s (category=%s)\n", meta.Name, meta.Category)
+	return 0
+}
+
+func runSkillEdit(store *skills.Store, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "用法: ainovel skill edit <name>")
+		return 1
+	}
+	name := args[0]
+
+	// 找到文件路径
+	metas := store.List("")
+	var target string
+	for _, m := range metas {
+		if m.Name == name {
+			target = m.Path
+			break
+		}
+	}
+	if target == "" {
+		fmt.Fprintf(os.Stderr, "skill %q 不存在\n", name)
+		return 1
+	}
+
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = defaultEditor()
+	}
+
+	cmd := exec.Command(editor, target)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "编辑器退出失败: %v\n", err)
+		return 1
+	}
+	if err := store.Refresh(); err != nil {
+		fmt.Fprintf(os.Stderr, "刷新索引失败: %v\n", err)
+		return 1
+	}
+	fmt.Printf("已更新 skill: %s\n", name)
+	return 0
+}
+
+func runSkillRemove(store *skills.Store, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "用法: ainovel skill remove <name>")
+		return 1
+	}
+	name := args[0]
+
+	// 确认
+	fmt.Printf("确认删除 skill %q 吗？输入 yes 继续: ", name)
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "读取确认失败: %v\n", err)
+		return 1
+	}
+	if strings.TrimSpace(strings.ToLower(line)) != "yes" {
+		fmt.Println("已取消删除。")
+		return 0
+	}
+
+	if err := store.Remove(name); err != nil {
+		fmt.Fprintf(os.Stderr, "删除失败: %v\n", err)
+		return 1
+	}
+	fmt.Printf("已删除 skill: %s\n", name)
+	return 0
+}
+
+func runSkillRefresh(store *skills.Store, args []string) int {
+	if err := store.Refresh(); err != nil {
+		fmt.Fprintf(os.Stderr, "刷新失败: %v\n", err)
+		return 1
+	}
+	fmt.Println("skill 索引已刷新。")
+	return 0
+}
+
+func defaultEditor() string {
+	if os.PathSeparator == '\\' {
+		return "notepad"
+	}
+	return "vi"
+}

--- a/internal/entry/tui/command_palette.go
+++ b/internal/entry/tui/command_palette.go
@@ -6,6 +6,27 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/voocel/ainovel-cli/internal/skills"
+)
+
+// 条目类型。
+//   - kindCommand：内置 / 命令（help / diag / model / ...）
+//   - kindSkill：跨书 skill 库条目
+//   - kindSkillEntry：命令列表里的 "Skill ▸" 子菜单入口，不直接补全
+const (
+	kindCommand    = "command"
+	kindSkill      = "skill"
+	kindSkillEntry = "skill-entry"
+)
+
+// paletteLevel 标识菜单层级。
+//   - paletteLevelCommands：一级，显示"命令 + Skill 入口"混合列表
+//   - paletteLevelSkills：选中 Skill 入口后展开的子菜单，只显示 skill 库内容
+type paletteLevel int
+
+const (
+	paletteLevelCommands paletteLevel = iota
+	paletteLevelSkills
 )
 
 type commandPaletteItem struct {
@@ -14,21 +35,83 @@ type commandPaletteItem struct {
 	Usage       string
 	Description string
 	AutoExecute bool
+	Kind        string // 缺省 kindCommand
+	Category    string // 仅 skill 用：genres / structures / ...
 }
 
 func builtinCommandItems() []commandPaletteItem {
 	return commandRegistryInstance().PaletteItems()
 }
 
+// skillPaletteItems 从 store 抽出当前所有 skill 元数据并转为菜单条目。
+// store 为 nil（库未启用）时返回 nil —— 子菜单为空，但入口仍可见。
+func skillPaletteItems(store *skills.Store) []commandPaletteItem {
+	if store == nil {
+		return nil
+	}
+	metas := store.List("")
+	items := make([]commandPaletteItem, 0, len(metas))
+	for _, m := range metas {
+		desc := m.Description
+		if desc == "" {
+			desc = "（无描述）"
+		}
+		items = append(items, commandPaletteItem{
+			Name:        m.Name,
+			Description: desc,
+			Usage:       "/" + m.Name + " [补充要求]",
+			Kind:        kindSkill,
+			Category:    m.Category,
+		})
+	}
+	return items
+}
+
+// commandsWithSkillEntry 在内置命令后追加 "Skill ▸" 子菜单入口。
+// 入口始终存在（即使 skill 库为空），描述里给出数量提示让用户判断是否值得展开。
+// 这样 skill 路径可发现，又不污染命令列表的高频入口（help/diag/...）。
+func commandsWithSkillEntry(store *skills.Store) []commandPaletteItem {
+	items := append([]commandPaletteItem(nil), builtinCommandItems()...)
+
+	skillCount := 0
+	if store != nil {
+		skillCount = len(store.List(""))
+	}
+	desc := "本地题材 / 结构 / 风格 skill 库"
+	if skillCount == 0 {
+		desc = "（skill 库为空，用 'ainovel skill add' 添加）"
+	} else {
+		desc = desc + "（" + strconv.Itoa(skillCount) + " 项）"
+	}
+
+	items = append(items, commandPaletteItem{
+		Name:        "Skill",
+		Description: desc,
+		Usage:       "→ 展开 skill 库",
+		Kind:        kindSkillEntry,
+	})
+	return items
+}
+
 func scoreCommandItem(item commandPaletteItem, query string) int {
 	if query == "" {
-		return 100
+		base := 100
+		switch item.Kind {
+		case kindSkill:
+			base = 60
+		case kindSkillEntry:
+			// Skill 入口在空查询时排末尾：它是个"补充路径"，不希望抢占 help/diag 等高频命令的视线。
+			// 用户主动输入 "skill" 时下面精确匹配分支会让它浮顶。
+			base = 40
+		}
+		return base
 	}
 
 	name := strings.ToLower(item.Name)
 	desc := strings.ToLower(item.Description)
 	usage := strings.ToLower(item.Usage)
 	aliases := strings.ToLower(strings.Join(item.Aliases, " "))
+	category := strings.ToLower(item.Category)
 
 	switch {
 	case name == query:
@@ -43,6 +126,8 @@ func scoreCommandItem(item commandPaletteItem, query string) int {
 		return 650
 	case strings.Contains(desc, query):
 		return 420
+	case category != "" && strings.Contains(category, query):
+		return 380
 	case strings.Contains(usage, query):
 		return 360
 	default:
@@ -50,9 +135,8 @@ func scoreCommandItem(item commandPaletteItem, query string) int {
 	}
 }
 
-func commandCompletions(prefix string) []commandPaletteItem {
-	query := strings.TrimSpace(strings.ToLower(prefix))
-	items := append([]commandPaletteItem(nil), builtinCommandItems()...)
+// sortAndFilter 共用排序+过滤。query 非空时丢弃零分条目。
+func sortAndFilter(items []commandPaletteItem, query string) []commandPaletteItem {
 	slices.SortStableFunc(items, func(a, b commandPaletteItem) int {
 		scoreA := scoreCommandItem(a, query)
 		scoreB := scoreCommandItem(b, query)
@@ -61,20 +145,31 @@ func commandCompletions(prefix string) []commandPaletteItem {
 		}
 		return strings.Compare(a.Name, b.Name)
 	})
-
-	var out []commandPaletteItem
-	for _, item := range items {
-		if scoreCommandItem(item, query) > 0 {
-			out = append(out, item)
+	if query == "" {
+		return items
+	}
+	out := items[:0]
+	for _, it := range items {
+		if scoreCommandItem(it, query) > 0 {
+			out = append(out, it)
 		}
 	}
 	return out
 }
 
-func (m *Model) clearCommandPalette() {
-	m.compItems = nil
-	m.compIdx = 0
-	m.compActive = false
+// commandCompletions 一级菜单用：返回"内置命令 + Skill 入口"，按 query 过滤。
+// Skill 入口在 query 命中 "skill" 时排前，否则随 base 分排在末尾（保持命令优先）。
+func commandCompletions(prefix string, store *skills.Store) []commandPaletteItem {
+	query := strings.TrimSpace(strings.ToLower(prefix))
+	items := commandsWithSkillEntry(store)
+	return sortAndFilter(items, query)
+}
+
+// skillCompletions 二级子菜单用：只返回 skill 库条目。
+func skillCompletions(prefix string, store *skills.Store) []commandPaletteItem {
+	query := strings.TrimSpace(strings.ToLower(prefix))
+	items := skillPaletteItems(store)
+	return sortAndFilter(items, query)
 }
 
 // syncCommandInputHighlight 复用命令注册表识别第一个 token。只记录完整、已注册的
@@ -94,6 +189,62 @@ func (m *Model) syncCommandInputHighlight() {
 	}
 }
 
+func (m *Model) clearCommandPalette() {
+	m.compItems = nil
+	m.compIdx = 0
+	m.compActive = false
+	m.compLevel = paletteLevelCommands
+}
+
+// enterSkillSubMenu 从命令列表进入 Skill 子菜单：清空 textarea 到 "/" 重新过滤。
+// 用 Esc 返回时调 exitSkillSubMenu。
+func (m *Model) enterSkillSubMenu() {
+	m.compLevel = paletteLevelSkills
+	m.compIdx = 0
+	m.textarea.Reset()
+	m.textarea.SetValue("/")
+	m.textarea.CursorEnd()
+	m.refreshCommandPaletteItems()
+}
+
+// exitSkillSubMenu 从 Skill 子菜单返回命令列表：恢复 textarea 到 "/" 并重建一级列表。
+func (m *Model) exitSkillSubMenu() {
+	m.compLevel = paletteLevelCommands
+	m.compIdx = 0
+	m.textarea.Reset()
+	m.textarea.SetValue("/")
+	m.textarea.CursorEnd()
+	m.refreshCommandPaletteItems()
+}
+
+// refreshCommandPaletteItems 按 compLevel 重新计算 compItems。
+// 抽出来避免 update / enter / exit 路径重复构造。
+func (m *Model) refreshCommandPaletteItems() {
+	var store *skills.Store
+	if m.runtime != nil {
+		store = m.runtime.SkillStore()
+	}
+
+	text := strings.TrimSpace(m.textarea.Value())
+	query := strings.TrimPrefix(text, "/")
+
+	switch m.compLevel {
+	case paletteLevelSkills:
+		m.compItems = skillCompletions(query, store)
+	default:
+		m.compItems = commandCompletions(query, store)
+	}
+
+	m.compActive = len(m.compItems) > 0
+	if !m.compActive {
+		m.compIdx = 0
+		return
+	}
+	if m.compIdx >= len(m.compItems) {
+		m.compIdx = max(0, len(m.compItems)-1)
+	}
+}
+
 func (m *Model) updateCommandPalette() {
 	m.syncCommandInputHighlight()
 	text := strings.TrimSpace(m.textarea.Value())
@@ -105,17 +256,7 @@ func (m *Model) updateCommandPalette() {
 		m.clearCommandPalette()
 		return
 	}
-
-	items := commandCompletions(strings.TrimPrefix(text, "/"))
-	m.compItems = items
-	m.compActive = len(items) > 0
-	if !m.compActive {
-		m.compIdx = 0
-		return
-	}
-	if m.compIdx >= len(items) {
-		m.compIdx = max(0, len(items)-1)
-	}
+	m.refreshCommandPaletteItems()
 }
 
 func (m *Model) selectedCommandItem() (commandPaletteItem, bool) {
@@ -125,11 +266,25 @@ func (m *Model) selectedCommandItem() (commandPaletteItem, bool) {
 	return m.compItems[m.compIdx], true
 }
 
+// acceptCommandCompletion 接受当前选中条目。
+//   - 一级 + Skill 入口：进入子菜单（不写入 textarea）
+//   - 一级 + 普通命令 / 二级 + skill：补全到 "/<name> " 让用户附加消息
+//
+// 返回 (item, true) 表示已补全（调用方可继续 AutoExecute 流程）；
+// 返回 (item, false) 表示"已切换层级，textarea 已重置，等待下一轮按键"。
 func (m *Model) acceptCommandCompletion() (commandPaletteItem, bool) {
 	item, ok := m.selectedCommandItem()
 	if !ok {
 		return commandPaletteItem{}, false
 	}
+
+	// Skill 子菜单入口：进入子菜单
+	if m.compLevel == paletteLevelCommands && item.Kind == kindSkillEntry {
+		m.enterSkillSubMenu()
+		return item, false
+	}
+
+	// 普通条目：补全到 /<name> 让用户继续
 	m.textarea.Reset()
 	m.textarea.SetValue("/" + item.Name + " ")
 	m.textarea.CursorEnd()
@@ -140,14 +295,14 @@ func (m *Model) acceptCommandCompletion() (commandPaletteItem, bool) {
 	return item, true
 }
 
-func renderCommandPalette(width int, items []commandPaletteItem, cursor int) string {
+func renderCommandPalette(width int, level paletteLevel, items []commandPaletteItem, cursor int) string {
 	if len(items) == 0 || width <= 0 {
 		return ""
 	}
 
 	boxW := width - 2
-	if boxW > 72 {
-		boxW = 72
+	if boxW > 84 {
+		boxW = 84
 	}
 	if boxW < 48 {
 		boxW = 48
@@ -160,11 +315,21 @@ func renderCommandPalette(width int, items []commandPaletteItem, cursor int) str
 	visible := items[start:end]
 	remaining := len(items) - end
 
+	// 配色：command 主色（金）；skill 次色（青绿）；Skill 入口用次色但加 ▸ 强调
 	nameStyle := lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
+	skillNameStyle := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true)
+	entryNameStyle := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true)
 	descStyle := lipgloss.NewStyle().Foreground(bodyTextColor)
 	mutedStyle := lipgloss.NewStyle().Foreground(colorMuted)
 	selectedNameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#1c1a14")).Background(colorAccent).Bold(true)
 	selectedDescStyle := lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
+
+	title := "命令"
+	hint := "↑↓ 选择 · Enter/Tab 接受 · → 展开 Skill · Esc 关闭"
+	if level == paletteLevelSkills {
+		title = "Skill 库"
+		hint = "↑↓ 选择 · Enter/Tab 接受 · ←/Esc 返回上级"
+	}
 
 	var body []string
 	selectedIdx := cursor - start
@@ -172,38 +337,62 @@ func renderCommandPalette(width int, items []commandPaletteItem, cursor int) str
 		prefix := "  "
 		nameRenderer := nameStyle
 		descRenderer := descStyle
+		displayName := item.Name
+		switch item.Kind {
+		case kindSkill:
+			nameRenderer = skillNameStyle
+			cat := strings.TrimSpace(item.Category)
+			if cat == "" {
+				cat = "skill"
+			}
+			displayName = "[" + cat + "] " + item.Name
+		case kindSkillEntry:
+			nameRenderer = entryNameStyle
+			displayName = item.Name + " ▸"
+		}
 		if i == selectedIdx {
 			prefix = "› "
 			nameRenderer = selectedNameStyle
 			descRenderer = selectedDescStyle
 		}
 
-		name := nameRenderer.Render(item.Name)
-		// truncateWidth 按视觉宽度截断（中文字符算 2 列）；用 truncate 会按 rune 数算，
-		// 中文场景实际宽度 = 期望的 2 倍，导致弹窗溢出。
-		desc := truncateWidth(item.Description, max(12, contentW-18))
+		// 动态算 desc 可用宽度：contentW - prefix(2) - displayName 宽 - gap(1)
+		// name 超长先截断 name；desc 至少留 8 列。
+		nameAvail := contentW - 2 - 1 - 8
+		if nameAvail < 8 {
+			nameAvail = 8
+		}
+		if lipgloss.Width(displayName) > nameAvail {
+			displayName = truncateWidth(displayName, nameAvail)
+		}
+		descAvail := contentW - 2 - lipgloss.Width(displayName) - 1
+		if descAvail < 8 {
+			descAvail = 8
+		}
+		desc := truncateWidth(item.Description, descAvail)
+
+		nameView := nameRenderer.Render(displayName)
 		descText := descRenderer.Render(desc)
-		line := prefix + name
-		gap := contentW - lipgloss.Width(line) - lipgloss.Width(descText)
+		gap := contentW - 2 - lipgloss.Width(displayName) - lipgloss.Width(desc)
 		if gap < 1 {
 			gap = 1
 		}
-		body = append(body, line+strings.Repeat(" ", gap)+descText)
+		body = append(body, prefix+nameView+strings.Repeat(" ", gap)+descText)
 	}
 
 	if selectedIdx < 0 || selectedIdx >= len(visible) {
 		selectedIdx = 0
 	}
-	hint := mutedStyle.Render("↑↓ 选择 · Tab/Enter 接受 · Esc 关闭")
 	usage := "Usage: " + visible[selectedIdx].Usage
 	if remaining > 0 {
-		usage = usage + " · 还有 " + strconv.Itoa(remaining) + " 个命令"
+		usage = usage + " · 还有 " + strconv.Itoa(remaining) + " 项"
 	}
 	usageLine := mutedStyle.Render(truncateWidth(usage, contentW))
 	body = append(body, usageLine+strings.Repeat(" ", max(0, contentW-lipgloss.Width(usageLine))))
-	body = append(body, hint+strings.Repeat(" ", max(0, contentW-lipgloss.Width(hint))))
+	hintLine := mutedStyle.Render(hint)
+	body = append(body, hintLine+strings.Repeat(" ", max(0, contentW-lipgloss.Width(hintLine))))
 
-	return renderPaddedModalFrame(boxW, len(body)+2, "命令", "", body)
+	return renderPaddedModalFrame(boxW, len(body)+2, title, "", body)
 }
 
 func commandPaletteWindow(total, cursor, limit int) (start, end int) {

--- a/internal/entry/tui/command_palette_test.go
+++ b/internal/entry/tui/command_palette_test.go
@@ -1,0 +1,130 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/voocel/ainovel-cli/internal/skills"
+)
+
+// TestSkillPaletteItemsConvertsMeta 验证 store.List 输出被正确映射为菜单条目。
+func TestSkillPaletteItemsConvertsMeta(t *testing.T) {
+	dir := t.TempDir()
+	store := skills.NewStore(dir)
+	if err := store.Add(skills.SkillMeta{
+		Name:        "cyberpunk-noir",
+		Description: "赛博朋克 + 黑色侦探题材清单",
+		Category:    "genres",
+		Tags:        []string{"sci-fi"},
+	}, "body content"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.Add(skills.SkillMeta{
+		Name:        "minimal-skill",
+		Description: "最小用例",
+	}, "body"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	items := skillPaletteItems(store)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d: %+v", len(items), items)
+	}
+
+	byName := map[string]commandPaletteItem{}
+	for _, it := range items {
+		byName[it.Name] = it
+	}
+	cs, ok := byName["cyberpunk-noir"]
+	if !ok {
+		t.Fatalf("missing cyberpunk-noir in %+v", items)
+	}
+	if cs.Kind != kindSkill || cs.Category != "genres" {
+		t.Fatalf("cyberpunk-noir kind/category mismatch: %+v", cs)
+	}
+	if cs.Usage != "/cyberpunk-noir [补充要求]" {
+		t.Fatalf("usage should mention skill inject format, got %q", cs.Usage)
+	}
+}
+
+// TestCommandCompletionsIncludesSkillEntry 验证一级命令列表末尾始终追加
+// "Skill ▸" 子菜单入口（即便 store 为 nil），让用户能发现 skill 路径。
+func TestCommandCompletionsIncludesSkillEntry(t *testing.T) {
+	// nil store：入口仍存在，但描述提示"为空"
+	items := commandCompletions("", nil)
+	last := items[len(items)-1]
+	if last.Kind != kindSkillEntry {
+		t.Fatalf("last item should be Skill entry, got %+v", last)
+	}
+	if last.Name != "Skill" {
+		t.Fatalf("Skill entry name mismatch: %+v", last)
+	}
+	if last.Description == "" {
+		t.Fatal("Skill entry should describe empty store")
+	}
+
+	// 有 skill 的 store：描述应包含数量
+	dir := t.TempDir()
+	store := skills.NewStore(dir)
+	for _, n := range []string{"a", "b", "c"} {
+		if err := store.Add(skills.SkillMeta{
+			Name: n, Description: "x", Category: "misc",
+		}, "body"); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+	}
+	items = commandCompletions("", store)
+	last = items[len(items)-1]
+	if last.Kind != kindSkillEntry {
+		t.Fatalf("last item should be Skill entry, got %+v", last)
+	}
+	if !containsStr(last.Description, "3") {
+		t.Fatalf("description should mention skill count 3: %q", last.Description)
+	}
+}
+
+// TestCommandCompletionsQuerySkillMatchesEntry 输入 "skill" 时一级菜单应让 Skill 入口浮顶，
+// 因为名字精确匹配。
+func TestCommandCompletionsQuerySkillMatchesEntry(t *testing.T) {
+	items := commandCompletions("skill", nil)
+	if len(items) == 0 {
+		t.Fatal("query 'skill' should at least match Skill entry")
+	}
+	if items[0].Kind != kindSkillEntry {
+		t.Fatalf("Skill entry should rank first for query 'skill', got %+v", items[0])
+	}
+}
+
+// TestSkillCompletionsFiltersByQuery 二级子菜单按查询词过滤。
+func TestSkillCompletionsFiltersByQuery(t *testing.T) {
+	dir := t.TempDir()
+	store := skills.NewStore(dir)
+	_ = store.Add(skills.SkillMeta{Name: "cyberpunk-noir", Description: "赛博朋克", Category: "genres"}, "body")
+	_ = store.Add(skills.SkillMeta{Name: "wuxia", Description: "武侠", Category: "genres"}, "body")
+
+	all := skillCompletions("", store)
+	if len(all) != 2 {
+		t.Fatalf("expected 2 skills on empty query, got %d", len(all))
+	}
+
+	filtered := skillCompletions("cyb", store)
+	if len(filtered) != 1 || filtered[0].Name != "cyberpunk-noir" {
+		t.Fatalf("query 'cyb' should match cyberpunk-noir only, got %+v", filtered)
+	}
+}
+
+// TestSkillCompletionsNilStore 二级子菜单 store 缺失时不 panic。
+func TestSkillCompletionsNilStore(t *testing.T) {
+	items := skillCompletions("any", nil)
+	if len(items) != 0 {
+		t.Fatalf("nil store should yield empty list, got %+v", items)
+	}
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/entry/tui/commands.go
+++ b/internal/entry/tui/commands.go
@@ -9,6 +9,7 @@ import (
 	"github.com/voocel/ainovel-cli/internal/domain"
 	"github.com/voocel/ainovel-cli/internal/entry/startup"
 	"github.com/voocel/ainovel-cli/internal/host"
+	"github.com/voocel/ainovel-cli/internal/skills"
 )
 
 type slashCommandSpec struct {
@@ -365,6 +366,27 @@ func prepareFileStart(args []string) (string, error) {
 func (m Model) handleSlashCommand(cmd slashCommand) (tea.Model, tea.Cmd) {
 	spec, ok := commandRegistryInstance().Find(cmd.name)
 	if !ok {
+		// 未注册命令：尝试作为 skill 引用展开（/skill-name 用户消息）
+		if m.runtime != nil {
+			userMsg := strings.Join(cmd.args, " ")
+			result := m.runtime.SkillInject(skills.InjectRequest{
+				SkillName: cmd.name,
+				UserMsg:   userMsg,
+			})
+			if result.Expanded {
+				return m.submitUserText(result.Text)
+			}
+			// 未命中：显示 hint，输入框已 reset，让用户重输
+			hint := result.Hint
+			if hint == "" {
+				hint = "未知命令：/" + cmd.name
+			}
+			m.applyEvent(host.Event{
+				Time: time.Now(), Category: "ERROR", Summary: hint, Level: "error",
+			})
+			m.refreshEventViewport()
+			return m, nil
+		}
 		m.applyEvent(host.Event{
 			Time: time.Now(), Category: "ERROR", Summary: "未知命令：/" + cmd.name, Level: "error",
 		})

--- a/internal/entry/tui/model.go
+++ b/internal/entry/tui/model.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/voocel/ainovel-cli/internal/host"
+	"github.com/voocel/ainovel-cli/internal/skills"
 	"github.com/voocel/ainovel-cli/internal/utils"
 )
 
@@ -65,6 +66,7 @@ type Model struct {
 	compItems      []commandPaletteItem
 	compIdx        int
 	compActive     bool
+	compLevel      paletteLevel // 当前菜单层级：命令列表 / skill 子菜单
 	commandToken   string // 当前已注册的命令 token；仅渲染该段，不染参数
 	snapshot       host.UISnapshot
 	events         []host.Event
@@ -680,7 +682,7 @@ func (m Model) View() string {
 	} else if m.modelConfig != nil {
 		view = overlayAboveInput(view, renderModelConfigModal(m.width, m.modelConfig), inputH)
 	} else if m.compActive {
-		commandBar := renderCommandPalette(m.width, m.compItems, m.compIdx)
+		commandBar := renderCommandPalette(m.width, m.compLevel, m.compItems, m.compIdx)
 		view = overlayAboveInput(view, commandBar, inputH)
 	}
 	return view
@@ -803,6 +805,21 @@ func (m Model) handleCoCreateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		text := utils.CleanInputLine(m.textarea.Value())
 		if text == "" {
 			return m, nil
+		}
+		// /skill-name 主动调用：展开为 skill 全文 + 用户补充
+		if req, ok := skills.ParseSkillRef(text); ok {
+			if m.runtime != nil {
+				result := m.runtime.SkillInject(req)
+				if result.Expanded {
+					text = result.Text
+				} else if hint := strings.TrimSpace(result.Hint); hint != "" {
+					m.applyEvent(host.Event{
+						Time: time.Now(), Category: "ERROR", Summary: hint, Level: "error",
+					})
+					m.refreshEventViewport()
+					return m, nil
+				}
+			}
 		}
 		m.err = nil
 		state.appendUser(text)

--- a/internal/entry/tui/model_update.go
+++ b/internal/entry/tui/model_update.go
@@ -138,8 +138,31 @@ func (m Model) handleCommandPaletteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool
 
 	switch msg.Type {
 	case tea.KeyEsc:
+		// Skill 子菜单：Esc 返回命令列表
+		// 命令列表：Esc 关闭菜单
+		if m.compLevel == paletteLevelSkills {
+			m.exitSkillSubMenu()
+			return m, nil, true
+		}
 		m.clearCommandPalette()
 		return m, nil, true
+	case tea.KeyLeft:
+		// ← 在 Skill 子菜单返回上级；命令列表忽略
+		if m.compLevel == paletteLevelSkills {
+			m.exitSkillSubMenu()
+			return m, nil, true
+		}
+		return m, nil, false
+	case tea.KeyRight:
+		// → 在命令列表选中 Skill 入口时进入子菜单；其他情况忽略
+		if m.compLevel == paletteLevelCommands {
+			item, ok := m.selectedCommandItem()
+			if ok && item.Kind == kindSkillEntry {
+				m.enterSkillSubMenu()
+				return m, nil, true
+			}
+		}
+		return m, nil, false
 	case tea.KeyUp:
 		if m.compIdx > 0 {
 			m.compIdx--
@@ -150,14 +173,13 @@ func (m Model) handleCommandPaletteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool
 			m.compIdx++
 		}
 		return m, nil, true
-	case tea.KeyTab:
-		m.acceptCommandCompletion()
-		return m, nil, true
-	case tea.KeyEnter:
+	case tea.KeyTab, tea.KeyEnter:
 		item, ok := m.acceptCommandCompletion()
+		// ok=false 表示"已切换层级"（进入或退出子菜单），textarea 已重置，等下次按键循环
 		if !ok {
 			return m, nil, true
 		}
+		// Skill 入口不会走到这里（acceptCommandCompletion 一级 Skill 入口返回 ok=false）
 		if item.AutoExecute {
 			m.textarea.Reset()
 			next, cmd := m.handleSlashCommand(slashCommand{name: item.Name})
@@ -300,6 +322,13 @@ func (m Model) handleEnterKey() (tea.Model, tea.Cmd) {
 	m.pushInputHistory(text)
 	m.textarea.Reset()
 	m.refitTextareaHeight()
+	return m.submitUserText(text)
+}
+
+// submitUserText 把一段文本作为用户输入提交到当前模式（modeNew/modeRunning/modeDone）。
+// 抽出来是为了让 skill 注入（/skill-name 展开）能复用同一套提交流程——
+// skill 注入本质上是把 /name + 用户消息替换为一段更长的用户消息。
+func (m Model) submitUserText(text string) (tea.Model, tea.Cmd) {
 	switch m.mode {
 	case modeNew:
 		m.err = nil

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -28,6 +28,7 @@ import (
 	"github.com/voocel/ainovel-cli/internal/notify"
 	"github.com/voocel/ainovel-cli/internal/revision"
 	"github.com/voocel/ainovel-cli/internal/rules"
+	"github.com/voocel/ainovel-cli/internal/skills"
 	storepkg "github.com/voocel/ainovel-cli/internal/store"
 	"github.com/voocel/ainovel-cli/internal/tools"
 	"github.com/voocel/ainovel-cli/internal/userrules"
@@ -53,6 +54,7 @@ type Host struct {
 	gate            *ChapterAdvanceGate // 章节许可与一次性暂停的统一政策组件
 	notifier        *notify.Notifier    // 无人值守告警；未启用为 nil（Send nil 安全）
 	configPath      string              // 配置写盘目标：/config、/model 就近写当前生效的那份（项目级存在则写它，否则全局）
+	skillStore      *skills.Store       // 跨书 skill 库；nil 表示未启用（路径解析失败），相关入口应优雅降级
 	logCleanup      func()
 	fileLogErr      error
 
@@ -208,6 +210,13 @@ func New(cfg bootstrap.Config, bundle assets.Bundle, options ...NewOption) (*Hos
 		lifecycle:       lifecycleIdle,
 	}
 	h.runCtx, h.runCancel = context.WithCancel(context.Background())
+
+	// 跨书 skill 库（TUI 注入 /skill-name 用）。失败不阻断启动：置 nil 后相关入口降级。
+	h.skillStore = skills.NewStore(filepath.Join(bootstrap.DefaultConfigDir(), "skills"))
+	if err := h.skillStore.Refresh(); err != nil {
+		h.skillStore = nil
+	}
+
 	h.observer = newObserver(store, h.emitEvent, h.emitDelta, h.emitClear)
 	// 宿主侧 Arbiter 与 Worker 共用同一条 ToolProgress → observer → 工作台链路。
 	h.runCtx = agentcore.WithToolProgress(h.runCtx, h.observer.workerProgress)
@@ -1980,4 +1989,29 @@ func (h *Host) continueAfterImport(opts imp.Options) bool {
 // 只读到 Progress.CompletedChapters + 章节终稿 + 大纲 + premise 的一致快照。
 func (h *Host) Export(ctx context.Context, opts exp.Options) (*exp.Result, error) {
 	return exp.Run(ctx, exp.Deps{Store: h.store}, opts)
+}
+
+// SkillStore 返回跨书 skill 库的引用。nil 表示 skill 库未启用
+// （路径解析失败或被禁用），调用方应优雅降级。
+func (h *Host) SkillStore() *skills.Store {
+	if h == nil {
+		return nil
+	}
+	return h.skillStore
+}
+
+// SkillInject 把 /skill-name 用户消息展开为最终发给 LLM 的文本。
+// 调用方（TUI / cocreate）先用 skills.ParseSkillRef 解析原始输入，
+// 命中再调本方法。返回 (展开后文本, 是否命中, 错误提示)。
+//
+// host 自身不解析输入——拆分"解析"和"展开"两个职责让 cocreate 等场景
+// 可以独立测试解析逻辑。
+func (h *Host) SkillInject(req skills.InjectRequest) skills.InjectResult {
+	if h == nil {
+		return skills.InjectResult{
+			Expanded: false,
+			Hint:     "host 未初始化",
+		}
+	}
+	return h.skillStore.InjectSkill(req)
 }

--- a/internal/skills/inject.go
+++ b/internal/skills/inject.go
@@ -1,0 +1,103 @@
+package skills
+
+import (
+	"fmt"
+	"strings"
+)
+
+// InjectRequest 描述一次 /skill-name 主动调用展开。
+// 调用方（TUI / cocreate）从用户原始输入解析出 SkillName 和 UserMsg，
+// 交给 Store 展开。
+type InjectRequest struct {
+	SkillName string // 不含前缀 /
+	UserMsg   string // 用户在 skill name 之后输入的额外说明，可为空
+}
+
+// InjectResult 是 InjectSkill 的返回。
+type InjectResult struct {
+	Expanded bool   // true=命中 skill 并已展开；false=未命中
+	Text     string // 展开后的完整消息（命中时）或原始回退（未命中时）
+	Hint     string // 未命中时的错误描述（供 UI 显示）
+}
+
+// InjectSkill 把 /skill-name 用户消息展开为最终发给 LLM 的文本。
+//
+// 命中时格式：
+//
+//	【已主动加载本地 skill：<name>】
+//
+//	<skill 全文（含 frontmatter）>
+//
+//	---
+//
+//	用户补充要求：<UserMsg>
+//	（UserMsg 为空时使用通用提示）
+//
+// 未命中（name 不存在）：返回 Expanded=false、Hint 描述错误。调用方决定如何处理
+// ——TUI 一般是显示错误并保留输入框，cocreate 同理。
+//
+// store 为 nil（禁用）时直接返回未命中 + 禁用提示。
+func (s *Store) InjectSkill(req InjectRequest) InjectResult {
+	name := strings.TrimSpace(req.SkillName)
+	if name == "" {
+		return InjectResult{Expanded: false, Hint: "skill 名称为空"}
+	}
+	if s == nil || s.root == "" {
+		return InjectResult{
+			Expanded: false,
+			Hint:     "本地 skill 库未启用（路径解析失败或禁用）。",
+		}
+	}
+	content, err := s.Read(name)
+	if err != nil {
+		// 给出近似建议：取前 5 个 name 供用户参考
+		hint := fmt.Sprintf("skill %q 不存在。", name)
+		all := s.List("")
+		if len(all) > 0 {
+			limit := 5
+			if len(all) < limit {
+				limit = len(all)
+			}
+			suggestions := make([]string, 0, limit)
+			for _, m := range all[:limit] {
+				suggestions = append(suggestions, m.Name)
+			}
+			hint += " 可用 skill（前 " + fmt.Sprintf("%d", limit) + " 个）：" + strings.Join(suggestions, ", ") + "。完整列表用 'ainovel skill list'。"
+		} else {
+			hint += " 当前 skill 库为空。"
+		}
+		return InjectResult{Expanded: false, Hint: hint}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("【已主动加载本地 skill：" + name + "】\n\n")
+	sb.WriteString(content)
+	sb.WriteString("\n\n---\n\n")
+	userMsg := strings.TrimSpace(req.UserMsg)
+	if userMsg != "" {
+		sb.WriteString("用户补充要求：" + userMsg)
+	} else {
+		sb.WriteString("（用户未补充具体要求。请基于上述 skill 内容给出建议、确认理解、或直接开始创作。）")
+	}
+	return InjectResult{Expanded: true, Text: sb.String()}
+}
+
+// ParseSkillRef 从用户原始输入解析出 InjectRequest。
+// 输入形如 "/cyberpunk-noir-checklist 帮我写开篇"。
+// 返回 ok=false 表示不是 skill 引用（不以 / 开头，或 / 后内容为空）。
+func ParseSkillRef(raw string) (InjectRequest, bool) {
+	text := strings.TrimSpace(raw)
+	if !strings.HasPrefix(text, "/") {
+		return InjectRequest{}, false
+	}
+	rest := strings.TrimPrefix(text, "/")
+	if strings.TrimSpace(rest) == "" {
+		return InjectRequest{}, false
+	}
+	parts := strings.SplitN(rest, " ", 2)
+	req := InjectRequest{SkillName: parts[0]}
+	if len(parts) > 1 {
+		req.UserMsg = strings.TrimSpace(parts[1])
+	}
+	return req, true
+}

--- a/internal/skills/parser.go
+++ b/internal/skills/parser.go
@@ -1,0 +1,346 @@
+// Package skills 实现跨书 skill 库的存储与检索。
+//
+// skill 是 Markdown + frontmatter 文件，存放在 ~/.ainovel/skills/<category>/<name>.md。
+// frontmatter 用一个极小的 YAML 子集解析（不引入外部依赖），仅支持：
+//
+//   - key: value              # scalar（字符串 / 整数）
+//   - key: "double quoted"    # 带引号 scalar
+//   - key: [a, b, c]          # inline 数组
+//   - key:                    # 块数组（缩进 - 开头）
+//       - a
+//       - b
+//   - key: |                  # 块 scalar（缩进多行）
+//       多行
+//       文本
+//
+// 仅 frontmatter、name 与 description 必填；其它字段可省略。
+package skills
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// SkillMeta 是 skill 文件的元数据，作为索引和工具返回的基本单位。
+// 字段 JSON tag 用 snake_case，方便工具返回直接 marshalling。
+type SkillMeta struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Category    string   `json:"category"`
+	Tags        []string `json:"tags,omitempty"`
+	Triggers    []string `json:"triggers,omitempty"`
+	When        string   `json:"when,omitempty"`
+	Do          string   `json:"do,omitempty"`
+	Priority    int      `json:"priority"`
+	Path        string   `json:"path,omitempty"`
+}
+
+// frontmatter 分隔符。
+const fmDelim = "---"
+
+// ParseSkill 解析 skill 文件全文，返回元数据、正文和错误。
+//
+// 行为：
+//   - 空文件 → 报错
+//   - 无 frontmatter（不以 --- 开头）→ 返回零元数据 + 整文为 body（不报错，
+//     由调用方决定是否接受）
+//   - frontmatter 缺闭合 --- → 报错
+//   - frontmatter 缺 name 或 description → 报错
+//   - priority 非整数 → 报错
+//   - 字段值不符合 YAML 子集 → 报错并指明行号
+//
+// category 缺省时从 path 的父目录名推断（如 ~/.ainovel/skills/genres/x.md → "genres"）。
+// priority 缺省时为 50（中等优先级）。
+func ParseSkill(path, raw string) (SkillMeta, string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return SkillMeta{}, "", fmt.Errorf("empty skill content")
+	}
+
+	meta := SkillMeta{Path: path, Priority: 50}
+
+	// 无 frontmatter：零元数据 + 整文为 body
+	if !strings.HasPrefix(raw, fmDelim+"\n") && raw != fmDelim {
+		return meta, raw, nil
+	}
+
+	lines := strings.Split(raw, "\n")
+	// 至少应有开头 --- + 内容 + 闭合 ---，少于 3 行肯定不完整
+	if len(lines) < 3 {
+		return meta, "", fmt.Errorf("invalid frontmatter: too short")
+	}
+
+	// 找闭合 ---
+	closeIdx := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimRight(lines[i], "\r") == fmDelim {
+			closeIdx = i
+			break
+		}
+	}
+	if closeIdx == -1 {
+		return meta, "", fmt.Errorf("invalid frontmatter: missing closing %s", fmDelim)
+	}
+
+	fmText := strings.Join(lines[1:closeIdx], "\n")
+	body := strings.TrimSpace(strings.Join(lines[closeIdx+1:], "\n"))
+
+	if err := parseFrontmatter(&meta, fmText); err != nil {
+		return meta, body, fmt.Errorf("parse frontmatter: %w", err)
+	}
+
+	if strings.TrimSpace(meta.Name) == "" {
+		return meta, body, fmt.Errorf("frontmatter: name is required")
+	}
+	if strings.TrimSpace(meta.Description) == "" {
+		return meta, body, fmt.Errorf("frontmatter: description is required")
+	}
+	if meta.Category == "" {
+		meta.Category = inferCategory(path)
+	}
+	return meta, body, nil
+}
+
+// parseFrontmatter 把 YAML 子集文本解析到 meta。详细语法见包注释。
+func parseFrontmatter(meta *SkillMeta, text string) error {
+	lines := strings.Split(text, "\n")
+	for i := 0; i < len(lines); {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			i++
+			continue
+		}
+
+		colonIdx := strings.Index(line, ":")
+		if colonIdx == -1 {
+			return fmt.Errorf("line %d: expected 'key: value', got %q", i+1, line)
+		}
+		key := strings.TrimSpace(line[:colonIdx])
+		rest := strings.TrimSpace(line[colonIdx+1:])
+
+		switch key {
+		case "tags", "triggers":
+			items, advance, err := parseListField(lines, i, rest, key)
+			if err != nil {
+				return err
+			}
+			if key == "tags" {
+				meta.Tags = items
+			} else {
+				meta.Triggers = items
+			}
+			i += advance
+
+		case "when", "do":
+			body, advance, err := parseScalarField(lines, i, rest, key)
+			if err != nil {
+				return err
+			}
+			if key == "when" {
+				meta.When = body
+			} else {
+				meta.Do = body
+			}
+			i += advance
+
+		case "priority":
+			n, err := strconv.Atoi(strings.TrimSpace(rest))
+			if err != nil {
+				return fmt.Errorf("line %d: priority must be integer, got %q", i+1, rest)
+			}
+			meta.Priority = n
+			i++
+
+		case "name", "description", "category":
+			val := unquote(strings.TrimSpace(rest))
+			switch key {
+			case "name":
+				meta.Name = val
+			case "description":
+				meta.Description = val
+			case "category":
+				meta.Category = val
+			}
+			i++
+
+		default:
+			// 未知字段忽略（向前兼容）
+			i++
+		}
+	}
+	return nil
+}
+
+// parseListField 解析 tags/triggers。支持两种形式：
+//
+//	key: [a, b, c]       inline
+//	key:                 block（后续缩进 - 开头的行）
+func parseListField(lines []string, i int, rest, key string) ([]string, int, error) {
+	if rest != "" {
+		items, err := parseInlineArray(rest)
+		if err != nil {
+			return nil, 0, fmt.Errorf("line %d: %s: %w", i+1, key, err)
+		}
+		return items, 1, nil
+	}
+
+	items, advance := parseBlockList(lines, i+1)
+	return items, 1 + advance, nil
+}
+
+// parseScalarField 解析 when/do。支持：
+//
+//	key: "single line"   单行带引号
+//	key: single line     单行裸
+//	key: |               块 scalar（后续缩进行）
+//	key: |-              块 scalar，去除末尾换行（YAML 语义，与 | 等价处理）
+func parseScalarField(lines []string, i int, rest, key string) (string, int, error) {
+	rest = strings.TrimSpace(rest)
+	if rest == "|" || rest == "|-" || rest == "|+" {
+		body, advance := parseBlockScalar(lines, i+1)
+		return body, 1 + advance, nil
+	}
+	if rest == "" {
+		// 空 value 视为块 scalar 容许（无内容）
+		body, advance := parseBlockScalar(lines, i+1)
+		return body, 1 + advance, nil
+	}
+	return unquote(rest), 1, nil
+}
+
+// parseBlockList 解析块数组。返回 items 和消耗的非空行数。
+func parseBlockList(lines []string, start int) ([]string, int) {
+	var items []string
+	i := start
+	for i < len(lines) {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+		if countIndent(line) == 0 {
+			break
+		}
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "- ") && trimmed != "-" {
+			break
+		}
+		var item string
+		if trimmed == "-" {
+			item = ""
+		} else {
+			item = unquote(strings.TrimSpace(trimmed[2:]))
+		}
+		items = append(items, item)
+		i++
+	}
+	return items, i - start
+}
+
+// parseBlockScalar 解析块 scalar（|）。返回内容和消耗的非空行数。
+// 缩进保留：剥离所有行共同的最小缩进。
+func parseBlockScalar(lines []string, start int) (string, int) {
+	var sb strings.Builder
+	baseIndent := -1
+	i := start
+	for i < len(lines) {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			sb.WriteString("\n")
+			i++
+			continue
+		}
+		indent := countIndent(line)
+		if indent == 0 {
+			break
+		}
+		if baseIndent == -1 {
+			baseIndent = indent
+		}
+		if indent < baseIndent {
+			break
+		}
+		sb.WriteString(line[baseIndent:])
+		sb.WriteString("\n")
+		i++
+	}
+	return strings.TrimRight(sb.String(), "\n"), i - start
+}
+
+// parseInlineArray 解析 [a, b, c] 形式内联数组。
+func parseInlineArray(s string) ([]string, error) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "[") || !strings.HasSuffix(s, "]") {
+		return nil, fmt.Errorf("array must be [a, b, c] form: %q", s)
+	}
+	inner := strings.TrimSpace(s[1 : len(s)-1])
+	if inner == "" {
+		return nil, nil
+	}
+	parts := strings.Split(inner, ",")
+	items := make([]string, 0, len(parts))
+	for _, p := range parts {
+		v := unquote(strings.TrimSpace(p))
+		if v == "" {
+			continue
+		}
+		items = append(items, v)
+	}
+	return items, nil
+}
+
+func countIndent(s string) int {
+	n := 0
+	for n < len(s) && (s[n] == ' ' || s[n] == '\t') {
+		n++
+	}
+	return n
+}
+
+// unquote 去掉包围引号（双或单）。无引号原样返回。
+func unquote(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 {
+		return s
+	}
+	if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+		inner := s[1 : len(s)-1]
+		if s[0] == '"' {
+			// 双引号走 JSON unescape，支持 \"、\n 等
+			var out string
+			if err := json.Unmarshal([]byte(s), &out); err == nil {
+				return out
+			}
+		}
+		return inner
+	}
+	return s
+}
+
+// inferCategory 从文件路径推断分类。取父目录名；不合法时退回 "misc"。
+func inferCategory(path string) string {
+	parts := strings.Split(strings.ReplaceAll(path, "\\", "/"), "/")
+	if len(parts) < 2 {
+		return "misc"
+	}
+	parent := parts[len(parts)-2]
+	if !isValidName(parent) {
+		return "misc"
+	}
+	return parent
+}
+
+// isValidName 校验 name/category 必须为 [a-z0-9-]+。
+func isValidName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9') && r != '-' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/skills/parser_test.go
+++ b/internal/skills/parser_test.go
@@ -1,0 +1,219 @@
+package skills
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseSkill_FullFrontmatter(t *testing.T) {
+	raw := `---
+name: cyberpunk-noir
+description: "赛博朋克 + 黑色侦探题材清单"
+category: genres
+tags: [sci-fi, cyberpunk, noir]
+triggers:
+  - 赛博朋克
+  - cyberpunk
+when: |
+  用户想写赛博朋克题材时
+  规划世界观与视觉锚点
+do: |
+  - 高密度都市
+  - 霓虹与雨夜
+priority: 70
+---
+
+# 标题
+
+正文段落。
+`
+	meta, body, err := ParseSkill("/home/u/.ainovel/skills/genres/cyberpunk-noir.md", raw)
+	if err != nil {
+		t.Fatalf("ParseSkill error: %v", err)
+	}
+	if meta.Name != "cyberpunk-noir" {
+		t.Errorf("Name = %q, want %q", meta.Name, "cyberpunk-noir")
+	}
+	if meta.Description != "赛博朋克 + 黑色侦探题材清单" {
+		t.Errorf("Description = %q", meta.Description)
+	}
+	if meta.Category != "genres" {
+		t.Errorf("Category = %q", meta.Category)
+	}
+	wantTags := []string{"sci-fi", "cyberpunk", "noir"}
+	if len(meta.Tags) != len(wantTags) {
+		t.Errorf("Tags = %v, want %v", meta.Tags, wantTags)
+	}
+	wantTriggers := []string{"赛博朋克", "cyberpunk"}
+	if len(meta.Triggers) != len(wantTriggers) {
+		t.Errorf("Triggers = %v, want %v", meta.Triggers, wantTriggers)
+	}
+	if !strings.Contains(meta.When, "用户想写赛博朋克题材时") {
+		t.Errorf("When = %q", meta.When)
+	}
+	if !strings.Contains(meta.Do, "高密度都市") {
+		t.Errorf("Do = %q", meta.Do)
+	}
+	if meta.Priority != 70 {
+		t.Errorf("Priority = %d", meta.Priority)
+	}
+	if !strings.Contains(body, "# 标题") {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestParseSkill_NoFrontmatter(t *testing.T) {
+	raw := "# Just Markdown\n\nbody only"
+	meta, body, err := ParseSkill("/tmp/foo.md", raw)
+	if err != nil {
+		t.Fatalf("expected no error for no-frontmatter file, got: %v", err)
+	}
+	if meta.Name != "" {
+		t.Errorf("Name should be empty, got %q", meta.Name)
+	}
+	if meta.Priority != 50 {
+		t.Errorf("default Priority = %d, want 50", meta.Priority)
+	}
+	if body != raw {
+		t.Errorf("body should equal input")
+	}
+}
+
+func TestParseSkill_EmptyFile(t *testing.T) {
+	_, _, err := ParseSkill("/tmp/x.md", "")
+	if err == nil {
+		t.Errorf("expected error for empty file")
+	}
+}
+
+func TestParseSkill_MissingName(t *testing.T) {
+	raw := `---
+description: "no name here"
+---
+body`
+	_, _, err := ParseSkill("/tmp/x.md", raw)
+	if err == nil {
+		t.Errorf("expected error for missing name")
+	}
+	if !strings.Contains(err.Error(), "name is required") {
+		t.Errorf("error should mention name, got: %v", err)
+	}
+}
+
+func TestParseSkill_MissingDescription(t *testing.T) {
+	raw := `---
+name: foo
+---
+body`
+	_, _, err := ParseSkill("/tmp/x.md", raw)
+	if err == nil {
+		t.Errorf("expected error for missing description")
+	}
+}
+
+func TestParseSkill_MissingCloseDelim(t *testing.T) {
+	raw := `---
+name: foo
+description: bar
+body without close`
+	_, _, err := ParseSkill("/tmp/x.md", raw)
+	if err == nil {
+		t.Errorf("expected error for missing close delim")
+	}
+}
+
+func TestParseSkill_InvalidPriority(t *testing.T) {
+	raw := `---
+name: foo
+description: bar
+priority: not-a-number
+---
+body`
+	_, _, err := ParseSkill("/tmp/x.md", raw)
+	if err == nil {
+		t.Errorf("expected error for non-integer priority")
+	}
+}
+
+func TestParseSkill_InferCategoryFromPath(t *testing.T) {
+	raw := `---
+name: foo
+description: bar
+---
+body`
+	meta, _, err := ParseSkill("/home/u/.ainovel/skills/genres/foo.md", raw)
+	if err != nil {
+		t.Fatalf("ParseSkill error: %v", err)
+	}
+	if meta.Category != "genres" {
+		t.Errorf("Category = %q, want %q (inferred from path)", meta.Category, "genres")
+	}
+}
+
+func TestParseSkill_InlineArrayWithSpaces(t *testing.T) {
+	raw := `---
+name: foo
+description: bar
+tags: [a, b, "c d", "e"]
+---
+body`
+	meta, _, err := ParseSkill("/tmp/x.md", raw)
+	if err != nil {
+		t.Fatalf("ParseSkill error: %v", err)
+	}
+	want := []string{"a", "b", "c d", "e"}
+	if len(meta.Tags) != len(want) {
+		t.Fatalf("Tags = %v, want %v", meta.Tags, want)
+	}
+	for i := range want {
+		if meta.Tags[i] != want[i] {
+			t.Errorf("Tags[%d] = %q, want %q", i, meta.Tags[i], want[i])
+		}
+	}
+}
+
+func TestParseSkill_QuotedDescription(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{`name: foo
+description: "包含: 冒号"
+`, "包含: 冒号"},
+		{`name: foo
+description: '单引号包围'
+`, "单引号包围"},
+		{`name: foo
+description: 裸值
+`, "裸值"},
+	}
+	for i, c := range cases {
+		raw := "---\n" + c.raw + "---\nbody"
+		meta, _, err := ParseSkill("/tmp/x.md", raw)
+		if err != nil {
+			t.Errorf("case %d error: %v", i, err)
+			continue
+		}
+		if meta.Description != c.want {
+			t.Errorf("case %d Description = %q, want %q", i, meta.Description, c.want)
+		}
+	}
+}
+
+func TestIsValidName(t *testing.T) {
+	cases := map[string]bool{
+		"cyberpunk-noir": true,
+		"abc123":         true,
+		"a":              true,
+		"":               false,
+		"Abc":            false, // 大写不允许
+		"abc_def":        false, // 下划线不允许
+		"abc.def":        false,
+		"中文":             false,
+	}
+	for input, want := range cases {
+		if got := isValidName(input); got != want {
+			t.Errorf("isValidName(%q) = %v, want %v", input, got, want)
+		}
+	}
+}

--- a/internal/skills/store.go
+++ b/internal/skills/store.go
@@ -1,0 +1,401 @@
+package skills
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Store 管理全局 skill 库（默认 ~/.ainovel/skills/<category>/<name>.md）。
+//
+// 设计：
+//   - 启动时调用 Refresh() 扫描磁盘，构建内存索引（仅元数据，不含正文）
+//   - 写入（Add/Remove）后自动 Refresh，保证索引一致
+//   - 用户外部编辑文件时，下次 Search/List 前按 mtime 懒重载
+//   - 解析失败的文件被跳过（best-effort），不影响其他 skill 可用
+//
+// 并发：所有读操作 RLock、写操作 Lock，工具调用安全。
+type Store struct {
+	root     string
+	mu       sync.RWMutex
+	index    []SkillMeta
+	lastScan time.Time
+}
+
+// NewStore 创建 store。root 为空时，所有操作返回空结果（不报错）——
+// 用于禁用 skill 库的场景（如配置错误时优雅降级）。
+func NewStore(root string) *Store {
+	return &Store{root: root}
+}
+
+// Root 返回根目录路径（CLI 展示用）。
+func (s *Store) Root() string { return s.root }
+
+// Refresh 扫描 root 重建索引。root 不存在时自动创建空目录。
+// 解析失败的文件被跳过（不影响整体），返回的 error 仅代表结构性问题（如目录无法创建）。
+func (s *Store) Refresh() error {
+	if s.root == "" {
+		return nil
+	}
+	if err := os.MkdirAll(s.root, 0o755); err != nil {
+		return fmt.Errorf("create skills dir: %w", err)
+	}
+
+	var index []SkillMeta
+	_ = filepath.WalkDir(s.root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // 访问失败：跳过此路径但不中止
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		meta, _, err := ParseSkill(path, string(raw))
+		if err != nil {
+			return nil // 解析失败：跳过单文件，不影响整体
+		}
+		// 仅当 frontmatter 缺失时 meta.Name 为空——也跳过
+		if meta.Name == "" {
+			return nil
+		}
+		index = append(index, meta)
+		return nil
+	})
+
+	s.mu.Lock()
+	s.index = index
+	s.lastScan = time.Now()
+	s.mu.Unlock()
+	return nil
+}
+
+// maybeRefresh 比较 root 的 mtime 与 lastScan，变化则重载。
+// 避免每次工具调用都全扫，但保证用户手动改文件能被感知。
+// 失败静默：最坏情况是读到旧索引，下次工具调用再试。
+func (s *Store) maybeRefresh() {
+	if s.root == "" {
+		return
+	}
+	info, err := os.Stat(s.root)
+	if err != nil {
+		return
+	}
+	s.mu.RLock()
+	last := s.lastScan
+	s.mu.RUnlock()
+	if info.ModTime().After(last) {
+		_ = s.Refresh()
+	}
+}
+
+// Search 按加权评分检索 skill。limit<=0 时取默认 5。
+//
+// 评分规则（query 非空时）：
+//   - tag 精确命中（不分大小写）：+30
+//   - trigger 部分匹配（query 包含或被包含）：+25
+//   - description 子串匹配：+15
+//   - name 子串匹配：+10
+//   - priority 仅在已命中时作微调加分：+ priority / 10
+//
+// query 为空：仅按 priority 排序返回前 limit 条（用于"列概览"场景）。
+//
+// 重要：query 非空时，必须 matchScore > 0 才算命中——priority 不会让不相关的
+// skill 出现在结果里。
+func (s *Store) Search(query string, limit int) []SkillMeta {
+	if limit <= 0 {
+		limit = 5
+	}
+	s.maybeRefresh()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	q := strings.ToLower(strings.TrimSpace(query))
+	type scored struct {
+		meta  SkillMeta
+		score int
+	}
+	hits := make([]scored, 0, len(s.index))
+	for _, m := range s.index {
+		if q == "" {
+			score := m.Priority
+			if score > 0 {
+				hits = append(hits, scored{m, score})
+			}
+			continue
+		}
+		matchScore := 0
+		if containsCI(m.Tags, q) {
+			matchScore += 30
+		}
+		for _, t := range m.Triggers {
+			tl := strings.ToLower(t)
+			if strings.Contains(tl, q) || strings.Contains(q, tl) {
+				matchScore += 25
+				break
+			}
+		}
+		if strings.Contains(strings.ToLower(m.Description), q) {
+			matchScore += 15
+		}
+		if strings.Contains(strings.ToLower(m.Name), q) {
+			matchScore += 10
+		}
+		if matchScore > 0 {
+			hits = append(hits, scored{m, matchScore + m.Priority/10})
+		}
+	}
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].score != hits[j].score {
+			return hits[i].score > hits[j].score
+		}
+		return hits[i].meta.Name < hits[j].meta.Name
+	})
+	if len(hits) > limit {
+		hits = hits[:limit]
+	}
+	out := make([]SkillMeta, 0, len(hits))
+	for _, h := range hits {
+		out = append(out, h.meta)
+	}
+	return out
+}
+
+// Read 返回某 skill 的完整文件内容（含 frontmatter）。
+// 不存在时返回错误（让 LLM 知道 name 错了）。
+func (s *Store) Read(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("skill name is empty")
+	}
+	s.maybeRefresh()
+	s.mu.RLock()
+	path := ""
+	for _, m := range s.index {
+		if m.Name == name {
+			path = m.Path
+			break
+		}
+	}
+	s.mu.RUnlock()
+	if path == "" {
+		return "", fmt.Errorf("skill %q not found", name)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read skill %s: %w", name, err)
+	}
+	return string(data), nil
+}
+
+// Add 写入新 skill 文件，frontmatter 由 caller 提供。
+//   - name 必须为 [a-z0-9-]+
+//   - category 缺省 "misc"，必须为 [a-z0-9-]+
+//   - 同名 skill 已存在 → 报错（不覆盖用户手改）
+//   - 写入成功后自动 Refresh 索引
+func (s *Store) Add(meta SkillMeta, body string) error {
+	name := strings.TrimSpace(meta.Name)
+	if name == "" {
+		return fmt.Errorf("skill name is required")
+	}
+	if !isValidName(name) {
+		return fmt.Errorf("skill name must match [a-z0-9-]+, got %q", name)
+	}
+	category := strings.TrimSpace(meta.Category)
+	if category == "" {
+		category = "misc"
+	}
+	if !isValidName(category) {
+		return fmt.Errorf("category must match [a-z0-9-]+, got %q", category)
+	}
+	if s.root == "" {
+		return fmt.Errorf("skill store root is empty (disabled)")
+	}
+
+	dir := filepath.Join(s.root, category)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create skill dir: %w", err)
+	}
+	path := filepath.Join(dir, name+".md")
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("skill %q already exists at %s", name, path)
+	}
+
+	content := renderSkillFile(meta, body)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("write skill: %w", err)
+	}
+	return s.Refresh()
+}
+
+// Remove 删除 skill。不存在返回错误。删除后自动 Refresh。
+func (s *Store) Remove(name string) error {
+	if name == "" {
+		return fmt.Errorf("skill name is empty")
+	}
+	s.maybeRefresh()
+	s.mu.RLock()
+	path := ""
+	for _, m := range s.index {
+		if m.Name == name {
+			path = m.Path
+			break
+		}
+	}
+	s.mu.RUnlock()
+	if path == "" {
+		return fmt.Errorf("skill %q not found", name)
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("remove skill %s: %w", name, err)
+	}
+	return s.Refresh()
+}
+
+// List 返回所有 skill 元数据。category 非空时按分类过滤。
+// 返回结果按 name 升序，便于 CLI 列表展示稳定。
+func (s *Store) List(category string) []SkillMeta {
+	s.maybeRefresh()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]SkillMeta, 0, len(s.index))
+	for _, m := range s.index {
+		if category != "" && m.Category != category {
+			continue
+		}
+		out = append(out, m)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Category != out[j].Category {
+			return out[i].Category < out[j].Category
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// Categories 返回所有现存分类（去重、升序）。CLI 列分类用。
+func (s *Store) Categories() []string {
+	s.maybeRefresh()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	seen := map[string]struct{}{}
+	for _, m := range s.index {
+		if m.Category == "" {
+			continue
+		}
+		seen[m.Category] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for c := range seen {
+		out = append(out, c)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// renderSkillFile 把 meta + body 序列化为 .md 文件全文（frontmatter + body）。
+// 写出的 frontmatter 严格符合 ParseSkill 的 YAML 子集，保证 round-trip。
+func renderSkillFile(meta SkillMeta, body string) string {
+	var sb strings.Builder
+	sb.WriteString("---\n")
+	sb.WriteString("name: " + meta.Name + "\n")
+	sb.WriteString("description: " + yamlScalar(meta.Description) + "\n")
+	if meta.Category != "" {
+		sb.WriteString("category: " + meta.Category + "\n")
+	}
+	if len(meta.Tags) > 0 {
+		sb.WriteString("tags: [" + strings.Join(quoteItems(meta.Tags), ", ") + "]\n")
+	}
+	if len(meta.Triggers) > 0 {
+		sb.WriteString("triggers: [" + strings.Join(quoteItems(meta.Triggers), ", ") + "]\n")
+	}
+	if strings.TrimSpace(meta.When) != "" {
+		sb.WriteString("when: |\n")
+		writeBlockScalar(&sb, meta.When)
+	}
+	if strings.TrimSpace(meta.Do) != "" {
+		sb.WriteString("do: |\n")
+		writeBlockScalar(&sb, meta.Do)
+	}
+	if meta.Priority > 0 && meta.Priority != 50 {
+		sb.WriteString(fmt.Sprintf("priority: %d\n", meta.Priority))
+	}
+	sb.WriteString("---\n\n")
+	sb.WriteString(strings.TrimSpace(body))
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// helpers -------------------------------------------------------------------
+
+// containsCI 不区分大小写判断 slice 是否包含 s。
+func containsCI(slice []string, s string) bool {
+	for _, x := range slice {
+		if strings.EqualFold(x, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// yamlScalar 把字符串编码为 YAML scalar。
+// 含特殊字符（:[]#*!|>'"%@`{} 等）或为空时用双引号 + JSON 转义；否则裸用。
+func yamlScalar(s string) string {
+	if s == "" {
+		return `""`
+	}
+	if needsYAMLQuote(s) {
+		b, _ := json.Marshal(s)
+		return string(b)
+	}
+	return s
+}
+
+// needsYAMLQuote 判断字符串是否含 YAML 中有结构含义的字符，
+// 含则需用引号包围以免被解析器误解。拆成多次 ContainsAny 是为了
+// 避免在双引号字符串字面量里同时转义 " ` { } 引起的视觉混乱。
+func needsYAMLQuote(s string) bool {
+	if strings.ContainsAny(s, ":[]#*,!|>'\"%@&") {
+		return true
+	}
+	if strings.ContainsAny(s, "{}") {
+		return true
+	}
+	if strings.ContainsRune(s, '`') {
+		return true
+	}
+	if strings.ContainsRune(s, '#') {
+		return true
+	}
+	if strings.ContainsRune(s, '*') {
+		return true
+	}
+	return false
+}
+
+func quoteItems(items []string) []string {
+	out := make([]string, len(items))
+	for i, s := range items {
+		out[i] = yamlScalar(s)
+	}
+	return out
+}
+
+func writeBlockScalar(sb *strings.Builder, text string) {
+	for _, line := range strings.Split(text, "\n") {
+		if line == "" {
+			sb.WriteString("\n")
+			continue
+		}
+		sb.WriteString("  " + line + "\n")
+	}
+}

--- a/internal/skills/store_test.go
+++ b/internal/skills/store_test.go
@@ -1,0 +1,282 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// helper：在 path 写一个最小合法 skill 文件
+func writeSkillFile(t *testing.T, path, name, desc, category string, tags []string) {
+	t.Helper()
+	content := "---\nname: " + name + "\ndescription: " + desc + "\ncategory: " + category + "\n"
+	if len(tags) > 0 {
+		content += "tags: ["
+		for i, tag := range tags {
+			if i > 0 {
+				content += ", "
+			}
+			content += tag
+		}
+		content += "]\n"
+	}
+	content += "priority: 50\n---\n\nbody\n"
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestStore_RefreshAndList(t *testing.T) {
+	root := t.TempDir()
+	writeSkillFile(t, filepath.Join(root, "genres", "a.md"), "a", "alpha", "genres", []string{"x"})
+	writeSkillFile(t, filepath.Join(root, "genres", "b.md"), "b", "beta", "genres", []string{"y"})
+	writeSkillFile(t, filepath.Join(root, "styles", "c.md"), "c", "gamma", "styles", nil)
+
+	s := NewStore(root)
+	if err := s.Refresh(); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	all := s.List("")
+	if len(all) != 3 {
+		t.Errorf("List = %d items, want 3", len(all))
+	}
+	genres := s.List("genres")
+	if len(genres) != 2 {
+		t.Errorf("List(genres) = %d, want 2", len(genres))
+	}
+	cats := s.Categories()
+	if len(cats) != 2 {
+		t.Errorf("Categories = %v", cats)
+	}
+}
+
+func TestStore_SearchTagHit(t *testing.T) {
+	root := t.TempDir()
+	writeSkillFile(t, filepath.Join(root, "genres", "cyber.md"), "cyberpunk", "赛博朋克题材", "genres", []string{"cyberpunk", "sci-fi"})
+	writeSkillFile(t, filepath.Join(root, "genres", "wuxia.md"), "wuxia", "武侠题材", "genres", []string{"wuxia", "ancient"})
+
+	s := NewStore(root)
+	_ = s.Refresh()
+
+	hits := s.Search("cyberpunk", 5)
+	if len(hits) != 1 {
+		t.Fatalf("Search = %d hits, want 1", len(hits))
+	}
+	if hits[0].Name != "cyberpunk" {
+		t.Errorf("Search[0].Name = %q, want cyberpunk", hits[0].Name)
+	}
+}
+
+func TestStore_SearchTriggerHit(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "genres", "x.md")
+	content := "---\nname: x\ndescription: foo\ncategory: genres\ntriggers:\n  - 赛博朋克\n  - 仿生人\npriority: 50\n---\nbody\n"
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewStore(root)
+	_ = s.Refresh()
+
+	hits := s.Search("我想写赛博朋克", 5)
+	if len(hits) == 0 {
+		t.Errorf("expected trigger hit, got 0")
+	}
+}
+
+func TestStore_SearchPriorityTieBreaker(t *testing.T) {
+	root := t.TempDir()
+	// 两个 skill 都有 tag "x"，priority 高的应排前
+	p1 := filepath.Join(root, "g", "a.md")
+	c1 := "---\nname: a\ndescription: alpha\ncategory: g\ntags: [x]\npriority: 80\n---\nbody\n"
+	p2 := filepath.Join(root, "g", "b.md")
+	c2 := "---\nname: b\ndescription: beta\ncategory: g\ntags: [x]\npriority: 60\n---\nbody\n"
+	os.MkdirAll(filepath.Dir(p1), 0o755)
+	os.WriteFile(p1, []byte(c1), 0o644)
+	os.WriteFile(p2, []byte(c2), 0o644)
+
+	s := NewStore(root)
+	_ = s.Refresh()
+
+	hits := s.Search("x", 5)
+	if len(hits) != 2 {
+		t.Fatalf("Search = %d, want 2", len(hits))
+	}
+	if hits[0].Name != "a" {
+		t.Errorf("Search[0].Name = %q, want a (higher priority)", hits[0].Name)
+	}
+}
+
+func TestStore_Read(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "g", "foo.md")
+	content := "---\nname: foo\ndescription: bar\ncategory: g\n---\n\n# Title\nbody\n"
+	os.MkdirAll(filepath.Dir(path), 0o755)
+	os.WriteFile(path, []byte(content), 0o644)
+
+	s := NewStore(root)
+	_ = s.Refresh()
+
+	body, err := s.Read("foo")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if body != content {
+		t.Errorf("Read returned %q, want %q", body, content)
+	}
+
+	if _, err := s.Read("nonexistent"); err == nil {
+		t.Errorf("Read nonexistent should error")
+	}
+}
+
+func TestStore_AddAndRemove(t *testing.T) {
+	root := t.TempDir()
+	s := NewStore(root)
+	_ = s.Refresh()
+
+	meta := SkillMeta{
+		Name:        "new-skill",
+		Description: "新增 skill",
+		Category:    "genres",
+		Tags:        []string{"new"},
+	}
+	if err := s.Add(meta, "# 新增\nbody"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Add 后立即可 Search
+	hits := s.Search("new", 5)
+	if len(hits) != 1 || hits[0].Name != "new-skill" {
+		t.Fatalf("Search after Add = %v, want [new-skill]", hits)
+	}
+
+	// 文件确实落盘
+	path := filepath.Join(root, "genres", "new-skill.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("file not created: %v", err)
+	}
+
+	// 重复 Add 报错
+	if err := s.Add(meta, "body"); err == nil {
+		t.Errorf("Add duplicate should error")
+	}
+
+	// Remove
+	if err := s.Remove("new-skill"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	hits = s.Search("new", 5)
+	if len(hits) != 0 {
+		t.Errorf("Search after Remove = %d, want 0", len(hits))
+	}
+
+	// Remove 不存在报错
+	if err := s.Remove("nonexistent"); err == nil {
+		t.Errorf("Remove nonexistent should error")
+	}
+}
+
+func TestStore_AddInvalidName(t *testing.T) {
+	root := t.TempDir()
+	s := NewStore(root)
+	_ = s.Refresh()
+
+	cases := []string{"", "UPPER", "under_score", "中文", "dot.dot"}
+	for _, name := range cases {
+		meta := SkillMeta{Name: name, Description: "x", Category: "g"}
+		if err := s.Add(meta, "body"); err == nil {
+			t.Errorf("Add with name %q should error", name)
+		}
+	}
+}
+
+func TestStore_LazyReloadOnMtimeChange(t *testing.T) {
+	root := t.TempDir()
+	s := NewStore(root)
+	_ = s.Refresh()
+
+	// 初始空
+	if hits := s.List(""); len(hits) != 0 {
+		t.Fatalf("expected empty, got %d", len(hits))
+	}
+
+	// 写入新文件
+	path := filepath.Join(root, "g", "x.md")
+	os.MkdirAll(filepath.Dir(path), 0o755)
+	content := "---\nname: x\ndescription: y\ncategory: g\n---\nbody\n"
+	os.WriteFile(path, []byte(content), 0o644)
+
+	// 推进 root 目录 mtime（maybeRefresh 检测的是 root 目录的 mtime，
+	// 不是单个文件的 mtime——文件创建时父目录 mtime 通常会更新，但保险起见显式 Chtimes）
+	newMtime := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(root, newMtime, newMtime); err != nil {
+		t.Logf("Chtimes: %v (可能不受支持，跳过)", err)
+	}
+
+	// 再 List 应触发懒重载
+	hits := s.List("")
+	if len(hits) != 1 {
+		t.Errorf("after mtime change, List = %d, want 1", len(hits))
+	}
+}
+
+func TestStore_EmptyRoot(t *testing.T) {
+	s := NewStore("") // 禁用
+	if err := s.Refresh(); err != nil {
+		t.Errorf("Refresh on empty root should not error, got %v", err)
+	}
+	if hits := s.Search("x", 5); len(hits) != 0 {
+		t.Errorf("Search on empty root = %d, want 0", len(hits))
+	}
+	if cats := s.Categories(); len(cats) != 0 {
+		t.Errorf("Categories on empty root = %v", cats)
+	}
+}
+
+func TestRenderSkillFile_RoundTrip(t *testing.T) {
+	meta := SkillMeta{
+		Name:        "round-trip",
+		Description: "包含: 冒号的描述",
+		Category:    "genres",
+		Tags:        []string{"a", "b c"},
+		When:        "场景\n多行",
+		Do:          "动作 1\n动作 2",
+		Priority:    80,
+	}
+	body := "# 标题\n\n正文段落\n"
+	content := renderSkillFile(meta, body)
+
+	// 解析回来应一致
+	parsed, parsedBody, err := ParseSkill("/tmp/x.md", content)
+	if err != nil {
+		t.Fatalf("round-trip ParseSkill: %v\ncontent:\n%s", err, content)
+	}
+	if parsed.Name != meta.Name {
+		t.Errorf("Name %q != %q", parsed.Name, meta.Name)
+	}
+	if parsed.Description != meta.Description {
+		t.Errorf("Description %q != %q", parsed.Description, meta.Description)
+	}
+	if parsed.Category != meta.Category {
+		t.Errorf("Category %q != %q", parsed.Category, meta.Category)
+	}
+	if len(parsed.Tags) != len(meta.Tags) {
+		t.Errorf("Tags len %d != %d", len(parsed.Tags), len(meta.Tags))
+	}
+	if parsed.Priority != meta.Priority {
+		t.Errorf("Priority %d != %d", parsed.Priority, meta.Priority)
+	}
+	// ParseSkill 对 body 做 TrimSpace，所以末尾换行不保留——比较时去边白
+	if strings.TrimSpace(parsedBody) != strings.TrimSpace(body) {
+		t.Errorf("body round-trip mismatch:\n got: %q\nwant: %q", parsedBody, body)
+	}
+}

--- a/internal/tools/skill_read.go
+++ b/internal/tools/skill_read.go
@@ -1,0 +1,69 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/voocel/agentcore/schema"
+	"github.com/voocel/ainovel-cli/internal/errs"
+	"github.com/voocel/ainovel-cli/internal/skills"
+)
+
+// SkillReadTool 加载某 skill 的完整 Markdown 内容（含 frontmatter）。
+// 配合 search_skills：先检索拿到 name，再读全文获取详细套路/清单。
+type SkillReadTool struct {
+	store *skills.Store
+}
+
+func NewSkillReadTool(store *skills.Store) *SkillReadTool {
+	return &SkillReadTool{store: store}
+}
+
+func (t *SkillReadTool) Name() string  { return "read_skill" }
+func (t *SkillReadTool) Label() string { return "读取 skill 全文" }
+
+func (t *SkillReadTool) Description() string {
+	return "读取本地 skill 库中某 skill 的完整 Markdown 内容（含 frontmatter 元数据）。" +
+		"先用 search_skills 检索拿到 name，再调本工具读全文。" +
+		"返回 {name, content, length}；name 不存在时返回错误。"
+}
+
+func (t *SkillReadTool) ReadOnly(_ json.RawMessage) bool        { return true }
+func (t *SkillReadTool) ConcurrencySafe(_ json.RawMessage) bool { return true }
+
+func (t *SkillReadTool) ActivityDescription(_ json.RawMessage) string {
+	return "读取 skill 全文"
+}
+
+func (t *SkillReadTool) Schema() map[string]any {
+	return schema.Object(
+		schema.Property("name", schema.String("skill 名称（来自 search_skills 返回的 name 字段）")).Required(),
+	)
+}
+
+func (t *SkillReadTool) Execute(ctx context.Context, args json.RawMessage) (json.RawMessage, error) {
+	var a struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, fmt.Errorf("invalid args: %w: %w", errs.ErrToolArgs, err)
+	}
+	name := strings.TrimSpace(a.Name)
+	if name == "" {
+		return nil, fmt.Errorf("name 不能为空: %w", errs.ErrToolArgs)
+	}
+	if t.store == nil {
+		return nil, fmt.Errorf("本地 skill 库未启用")
+	}
+	content, err := t.store.Read(name)
+	if err != nil {
+		return nil, fmt.Errorf("read skill %s: %w", name, err)
+	}
+	return json.Marshal(map[string]any{
+		"name":    name,
+		"content": content,
+		"length":  len([]rune(content)),
+	})
+}

--- a/internal/tools/skill_search.go
+++ b/internal/tools/skill_search.go
@@ -1,0 +1,109 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/voocel/agentcore/schema"
+	"github.com/voocel/ainovel-cli/internal/errs"
+	"github.com/voocel/ainovel-cli/internal/skills"
+)
+
+// SkillSearchTool 让 architect 在本地跨书 skill 库（~/.ainovel/skills/）
+// 中按关键词检索可复用经验（题材套路、结构模板、风格预设、流派常识等）。
+//
+// 与 web_search 的关系：本工具是"本地优先"层——零成本、零延迟、可复用。
+// 命中后再用 skill_read 读全文；未命中（count=0）再走 web_search 联网搜索。
+type SkillSearchTool struct {
+	store *skills.Store
+}
+
+func NewSkillSearchTool(store *skills.Store) *SkillSearchTool {
+	return &SkillSearchTool{store: store}
+}
+
+func (t *SkillSearchTool) Name() string  { return "search_skills" }
+func (t *SkillSearchTool) Label() string { return "检索本地 skill 库" }
+
+func (t *SkillSearchTool) Description() string {
+	return "在本地跨书 skill 库（~/.ainovel/skills/）中按关键词检索可复用经验——" +
+		"题材套路、结构模板、风格预设、流派常识、创作流程清单等。" +
+		"返回 top-N 元数据（name/description/category/tags/priority），命中后再调 read_skill 读全文。" +
+		"零联网成本、零延迟；未命中（count=0）时再走 web_search。" +
+		"典型场景：用户提到某流派（赛博朋克、武侠、克苏鲁...）或结构（三幕剧、双线叙事...）时先调本工具查有没有相关 skill。"
+}
+
+// 纯读，并发安全。
+func (t *SkillSearchTool) ReadOnly(_ json.RawMessage) bool        { return true }
+func (t *SkillSearchTool) ConcurrencySafe(_ json.RawMessage) bool { return true }
+
+func (t *SkillSearchTool) ActivityDescription(_ json.RawMessage) string {
+	return "检索本地 skill 库"
+}
+
+func (t *SkillSearchTool) Schema() map[string]any {
+	return schema.Object(
+		schema.Property("query", schema.String("检索关键词，流派名/结构名/风格特征等（中英文均可）")).Required(),
+		schema.Property("category", schema.String("可选：限定分类（如 genres/structures/styles/tropes/processes）")),
+		schema.Property("limit", schema.Int("返回上限，默认 5，最大 20")),
+	)
+}
+
+func (t *SkillSearchTool) Execute(ctx context.Context, args json.RawMessage) (json.RawMessage, error) {
+	var a struct {
+		Query    string `json:"query"`
+		Category string `json:"category"`
+		Limit    int    `json:"limit"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, fmt.Errorf("invalid args: %w: %w", errs.ErrToolArgs, err)
+	}
+	q := strings.TrimSpace(a.Query)
+	if q == "" {
+		return nil, fmt.Errorf("query 不能为空: %w", errs.ErrToolArgs)
+	}
+	if t.store == nil {
+		// store 未配置（如 ~/.ainovel 路径解析失败）→ 返回空结果而非错误，
+		// 让 LLM 知道本工具不可用、走 web_search fallback。
+		return json.Marshal(map[string]any{
+			"query":   q,
+			"results": []any{},
+			"count":   0,
+			"hint":    "本地 skill 库未启用（路径解析失败或禁用）。请走 web_search 联网搜索。",
+		})
+	}
+	if a.Limit <= 0 {
+		a.Limit = 5
+	}
+	if a.Limit > 20 {
+		a.Limit = 20
+	}
+
+	metas := t.store.Search(q, a.Limit)
+	results := make([]map[string]any, 0, len(metas))
+	for _, m := range metas {
+		if a.Category != "" && m.Category != a.Category {
+			continue
+		}
+		results = append(results, map[string]any{
+			"name":        m.Name,
+			"description": m.Description,
+			"category":    m.Category,
+			"tags":        m.Tags,
+			"triggers":    m.Triggers,
+			"priority":    m.Priority,
+		})
+	}
+
+	out := map[string]any{
+		"query":   q,
+		"results": results,
+		"count":   len(results),
+	}
+	if len(results) == 0 {
+		out["hint"] = "本地 skill 库未命中。可改走 web_search 联网搜索，或基于已有知识工作。"
+	}
+	return json.Marshal(out)
+}


### PR DESCRIPTION
## 概述

新增 skill 跨书经验库：用户把可复用的写作经验（题材套路、结构模板、文风指南等）存成 Markdown 文件，规划阶段由 architect 按需检索参考。

## 组成

- `internal/skills`：Markdown skill 的解析（frontmatter 元数据）、全局存储（`~/.ainovel/skills/`）、上下文注入
- `ainovel skill` CLI 子命令：add / list / remove / path
- LLM 工具：`search_skills`（按关键词检索）、`read_skill`（读取全文），挂载到 architect
- TUI：命令面板新增 `Skill ▸` 子菜单；输入 `/skill名` 直接把 skill 展开为创作指令注入

## 设计要点

- skill 存全局配置目录（跨书共享），与项目级 store 分离
- skill 库加载失败时降级为 nil（工具不挂载、面板子菜单为空），不影响主创作流程
- 命令面板一级列表保持命令优先，Skill 入口排在末尾，不抢占 help / diag 等高频命令的视线

## 测试

- `internal/skills` 单元测试覆盖解析 / 存储 / 注入
- `go build ./...` / `go vet ./...` 通过
