### PR TITLE
feat: 启动时自动检查新版本并提醒升级

### DIFF
--- a/cmd/ainovel-cli/main.go
+++ b/cmd/ainovel-cli/main.go
@@ -205,7 +205,7 @@ func versionInfo() buildversion.Info {
 func runSelfUpdate(target string) error {
 	info := versionInfo()
 	result, err := buildversion.Update(context.Background(), buildversion.UpdateOptions{
-		Repo:           "voocel/ainovel-cli",
+		Repo:           buildversion.DefaultRepo,
 		BinaryName:     "ainovel-cli",
 		TargetVersion:  target,
 		CurrentVersion: info.Version,

--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -141,4 +141,9 @@
   //   // ntfy (iOS/Android): "command": "curl -s -G --data-urlencode \"title=$NOTIFY_TITLE\" --data-urlencode \"message=$NOTIFY_BODY\" ntfy.sh/<topic>/publish"
   //   "events": ["run_end", "budget", "advance_gate", "stop_guard", "plan_start", "deadlock", "worker_failure"]
   // }
+
+  // 可选。置 true 关闭启动时的新版本检查提醒（默认开）。检查只读 GitHub Releases
+  // 公开接口，结果本地缓存 24h；发现新版本时在欢迎页/事件流提示版本号与更新内容，
+  // 是否升级始终由你运行 ainovel-cli update 决定。
+  // "disable_update_check": false
 }

--- a/internal/bootstrap/config.example.jsonc
+++ b/internal/bootstrap/config.example.jsonc
@@ -141,4 +141,9 @@
   //   // ntfy (iOS/Android): "command": "curl -s -G --data-urlencode \"title=$NOTIFY_TITLE\" --data-urlencode \"message=$NOTIFY_BODY\" ntfy.sh/<topic>/publish"
   //   "events": ["run_end", "budget", "advance_gate", "stop_guard", "plan_start", "deadlock", "worker_failure"]
   // }
+
+  // 可选。置 true 关闭启动时的新版本检查提醒（默认开）。检查只读 GitHub Releases
+  // 公开接口，结果本地缓存 24h；发现新版本时在欢迎页/事件流提示版本号与更新内容，
+  // 是否升级始终由你运行 ainovel-cli update 决定。
+  // "disable_update_check": false
 }

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -226,6 +226,10 @@ type Config struct {
 
 	// Notify 无人值守告警配置；缺省启用（system 通道兜底）。
 	Notify NotifyConfig `json:"notify,omitzero"`
+
+	// DisableUpdateCheck 关闭启动时的新版本检查提醒（默认开）。检查只读
+	// GitHub Releases 公开接口，结果缓存在本地配置目录，不上报任何数据。
+	DisableUpdateCheck bool `json:"disable_update_check,omitempty"`
 }
 
 // BudgetConfig 是用户对单本书钱包的政策声明。越线停机等同于用户在那一刻

--- a/internal/entry/tui/app.go
+++ b/internal/entry/tui/app.go
@@ -29,6 +29,7 @@ func Run(cfg bootstrap.Config, bundle assets.Bundle, build buildversion.Info) er
 	defer rt.Close()
 
 	m := NewModel(rt, build.Version)
+	m.disableUpdateCheck = cfg.DisableUpdateCheck
 	if logErr := rt.FileLogError(); logErr != nil {
 		logWarning := fmt.Errorf("文件日志不可用，已继续使用终端日志：%w", logErr)
 		m.err = logWarning

--- a/internal/entry/tui/events.go
+++ b/internal/entry/tui/events.go
@@ -2,12 +2,15 @@ package tui
 
 import (
 	"context"
+	"path/filepath"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/voocel/ainovel-cli/internal/bootstrap"
 	"github.com/voocel/ainovel-cli/internal/diag"
 	"github.com/voocel/ainovel-cli/internal/host"
 	"github.com/voocel/ainovel-cli/internal/store"
+	buildversion "github.com/voocel/ainovel-cli/internal/version"
 )
 
 // 消息类型
@@ -53,9 +56,29 @@ type (
 	streamClearMsg     struct{}  // 清空流式缓冲（新消息开始）
 	streamFlushTickMsg struct{}  // 流式刷新节流（仅有待刷数据时调度）
 	quitResetMsg       struct{}  // 双次 Ctrl+C 超时重置
+	updateAvailableMsg struct {  // 启动版本检查命中新版本（result 非 nil 才会发出）
+		result *buildversion.CheckResult
+	}
 )
 
 // --- Cmd 函数 ---
+
+// checkForUpdate 后台查询上游新版本（5s 超时，24h 缓存节流）。失败与"无更新"
+// 都返回 nil——检查是纯提醒，任何网络问题都不该打扰用户。
+func checkForUpdate(currentVersion string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		res, err := buildversion.CheckUpdate(ctx, buildversion.CheckOptions{
+			CurrentVersion: currentVersion,
+			CachePath:      filepath.Join(bootstrap.DefaultConfigDir(), "update-check.json"),
+		})
+		if err != nil || res == nil || !res.UpdateAvailable {
+			return nil
+		}
+		return updateAvailableMsg{result: res}
+	}
+}
 
 func listenEvents(rt *host.Host) tea.Cmd {
 	return func() tea.Msg {

--- a/internal/entry/tui/model.go
+++ b/internal/entry/tui/model.go
@@ -93,6 +93,8 @@ type Model struct {
 	starting       bool // UI 已进入工作台，Host 正在执行启动初始化
 	startupMode    startupMode
 	importHint     string // 启动时检测到未完成导入的提示（欢迎屏显示；发起导入后清空）
+	updateHint     string // 启动版本检查发现新版本的提示（欢迎屏显示；详情经事件流浮出）
+	disableUpdateCheck bool // 配置关闭启动版本检查（bootstrap.Config.DisableUpdateCheck）
 	cocreateSeq    int
 	reportSeq      int
 	err            error
@@ -160,7 +162,7 @@ func NewModel(rt *host.Host, version string) Model {
 }
 
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(
+	cmds := []tea.Cmd{
 		textarea.Blink,
 		listenEvents(m.runtime),
 		listenDone(m.runtime),
@@ -168,7 +170,12 @@ func (m Model) Init() tea.Cmd {
 		tickSnapshot(m.runtime),
 		bootstrapRuntime(m.runtime),
 		tickSpinner(),
-	)
+	}
+	// 启动版本检查：后台一次，命中才浮出提醒（checkForUpdate 内部静默所有失败）。
+	if !m.disableUpdateCheck {
+		cmds = append(cmds, checkForUpdate(m.version))
+	}
+	return tea.Batch(cmds...)
 }
 
 func (m *Model) paneAtMouse(x, y int) (focusPane, bool) {
@@ -646,7 +653,7 @@ func (m Model) View() string {
 		if m.err != nil {
 			errMsg = m.err.Error()
 		}
-		body = renderWelcome(m.width, bodyH, errMsg, m.startupMode, m.importHint)
+		body = renderWelcome(m.width, bodyH, errMsg, m.startupMode, m.importHint, m.updateHint)
 	} else {
 		leftW := m.sidebarWidth()
 		rightW := m.detailWidth()

--- a/internal/entry/tui/model_update.go
+++ b/internal/entry/tui/model_update.go
@@ -572,6 +572,24 @@ func (m Model) handleRuntimeMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		}
 		m.refreshEventViewport()
 		return m, nil, true
+	case updateAvailableMsg:
+		// 启动版本检查命中新版本：事件流浮出一行提醒，release notes 全文进
+		// Detail（右侧详情面板可回看）；欢迎屏同步显示一行升级入口提示。
+		// 升级与否始终由用户运行 ainovel-cli update 决定。
+		if msg.result == nil || !msg.result.UpdateAvailable {
+			return m, nil, true
+		}
+		m.updateHint = fmt.Sprintf("新版本 %s 已发布 · 运行 ainovel-cli update 升级 · 更新内容见事件流", msg.result.Latest)
+		ev := host.Event{
+			Time: time.Now(), Category: "SYSTEM", Level: "info",
+			Summary: fmt.Sprintf("新版本 %s 已发布，运行 ainovel-cli update 升级", msg.result.Latest),
+		}
+		if notes := strings.TrimSpace(msg.result.Notes); notes != "" {
+			ev.Detail = notes
+		}
+		m.applyEvent(ev)
+		m.refreshEventViewport()
+		return m, nil, true
 	case revisionDoneMsg:
 		if msg.err != nil {
 			m.applyEvent(host.Event{Time: time.Now(), Category: "ERROR", Summary: "章节同步失败：" + msg.err.Error(), Level: "error"})

--- a/internal/entry/tui/panels.go
+++ b/internal/entry/tui/panels.go
@@ -141,7 +141,7 @@ func renderDetailPanel(vp viewport.Model, width, height int, focused bool) strin
 }
 
 // renderWelcome 渲染新建态首屏。
-func renderWelcome(width, height int, errMsg string, mode startupMode, importHint string) string {
+func renderWelcome(width, height int, errMsg string, mode startupMode, importHint, updateHint string) string {
 	// 简洁标题
 	title := lipgloss.NewStyle().
 		Foreground(colorAccent).
@@ -228,6 +228,13 @@ func renderWelcome(width, height int, errMsg string, mode startupMode, importHin
 	} else {
 		b.WriteString(lipgloss.NewStyle().Foreground(colorDim).
 			Render("已有设定/大纲？/start <文件路径> 创建新书 · 已有小说存稿？/import <文件路径> 导入续写"))
+	}
+	if updateHint != "" {
+		// 启动版本检查命中新版本：与 importHint 同款强调样式追加一行。
+		// 完整更新内容（release notes）已随 SYSTEM 事件进入事件流/详情面板。
+		b.WriteString("\n")
+		b.WriteString(lipgloss.NewStyle().Foreground(colorAccent2).Bold(true).
+			Render("! " + updateHint))
 	}
 	b.WriteString("\n\n")
 	b.WriteString(lipgloss.NewStyle().Foreground(colorDim).Italic(true).

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -1,0 +1,194 @@
+package version
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DefaultRepo 是版本检查与自更新默认指向的上游仓库。
+const DefaultRepo = "voocel/ainovel-cli"
+
+// DefaultCheckInterval 是两次联网检查之间的最小间隔。GitHub 匿名 API 限流
+// 60 req/h，且发版节奏是天级，更频繁的检查只有打扰没有收益。
+const DefaultCheckInterval = 24 * time.Hour
+
+// CheckOptions 是一次版本检查的输入。CachePath 由调用方传入（通常为
+// 配置目录下的 update-check.json）；本包不依赖 bootstrap，保持 version
+// 作为叶子包的依赖方向。
+type CheckOptions struct {
+	Repo           string
+	CurrentVersion string
+	Client         *http.Client
+	CachePath      string        // 空 = 不落盘，每次调用都联网
+	MaxAge         time.Duration // 缓存有效期；<=0 取 DefaultCheckInterval
+}
+
+// CheckResult 是版本检查的结论。Notes 携带 release 原文（markdown），
+// 供调用方在详情面板展示"更新了什么"，升级与否由用户决定。
+type CheckResult struct {
+	Latest          string
+	Current         string
+	Notes           string
+	UpdateAvailable bool
+	FromCache       bool
+}
+
+// checkCache 是 CachePath 的落盘结构。损坏或残缺的缓存视为不存在
+//（下次启动重新联网），不构成错误。
+type checkCache struct {
+	LastCheck time.Time `json:"last_check"`
+	Latest    string    `json:"latest"`
+	Notes     string    `json:"notes"`
+}
+
+// CheckUpdate 查询上游最新 release 并判断是否需要提醒升级。只读不写任何
+// 二进制；是否升级、何时升级完全由用户经 `ainovel-cli update` 决定。
+// 网络失败时回退过期缓存（旧提醒好过没有）；完全无数据返回 error，由调用方静默。
+func CheckUpdate(ctx context.Context, opts CheckOptions) (*CheckResult, error) {
+	current := Normalize(opts.CurrentVersion)
+	if current == "dev" {
+		// 本地构建没有可比较的版本语义，跳过检查避免把任意构建误报成"可升级"。
+		return &CheckResult{Current: current}, nil
+	}
+	repo := strings.TrimSpace(opts.Repo)
+	if repo == "" {
+		repo = DefaultRepo
+	}
+	maxAge := opts.MaxAge
+	if maxAge <= 0 {
+		maxAge = DefaultCheckInterval
+	}
+
+	var stale *checkCache
+	if opts.CachePath != "" {
+		if c, ok := loadCache(opts.CachePath); ok {
+			if time.Since(c.LastCheck) <= maxAge {
+				return c.result(current), nil
+			}
+			stale = c // 过期但结构完整：留作网络失败的兜底
+		}
+	}
+
+	client := opts.Client
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	rel, err := fetchRelease(ctx, client, repo, "latest")
+	if err != nil {
+		if stale != nil {
+			return stale.result(current), nil
+		}
+		return nil, err
+	}
+	if rel.TagName == "" {
+		if stale != nil {
+			return stale.result(current), nil
+		}
+		return nil, fmt.Errorf("release 缺少 tag_name")
+	}
+
+	// 缓存写失败只影响下次节流，本次结果照常返回。
+	_ = writeCache(opts.CachePath, rel)
+	return &CheckResult{
+		Latest:          rel.TagName,
+		Current:         current,
+		Notes:           rel.Body,
+		UpdateAvailable: isNewer(rel.TagName, current),
+	}, nil
+}
+
+// loadCache 读取并解析缓存；文件不存在、损坏或字段残缺一律视为无缓存。
+func loadCache(path string) (*checkCache, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	var c checkCache
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, false
+	}
+	if c.Latest == "" || c.LastCheck.IsZero() {
+		return nil, false
+	}
+	return &c, true
+}
+
+// result 把缓存内容转换为检查结论（FromCache=true）。
+func (c *checkCache) result(current string) *CheckResult {
+	return &CheckResult{
+		Latest:          c.Latest,
+		Current:         current,
+		Notes:           c.Notes,
+		UpdateAvailable: isNewer(c.Latest, current),
+		FromCache:       true,
+	}
+}
+
+// writeCache 落盘本次检查结果。目录不存在则创建；缓存丢失只意味着下次多一次联网。
+func writeCache(path string, rel *release) error {
+	if path == "" {
+		return nil
+	}
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	data, err := json.Marshal(checkCache{LastCheck: time.Now(), Latest: rel.TagName, Notes: rel.Body})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// isNewer 判断 latest 是否语义上新于 current。两边剥 "v" 前缀后按 "." 分段
+// 做数字比较，短的一方补零。任一段无法解析为非负整数（含 pre-release 后缀
+// 如 1.2.3-rc1）时保守返回 false——宁可漏提醒，不误提醒。
+func isNewer(latest, current string) bool {
+	a, ok := parseSemver(latest)
+	if !ok {
+		return false
+	}
+	b, ok := parseSemver(current)
+	if !ok {
+		return false
+	}
+	n := max(len(a), len(b))
+	for i := 0; i < n; i++ {
+		x, y := 0, 0
+		if i < len(a) {
+			x = a[i]
+		}
+		if i < len(b) {
+			y = b[i]
+		}
+		if x != y {
+			return x > y
+		}
+	}
+	return false
+}
+
+func parseSemver(v string) ([]int, bool) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if v == "" {
+		return nil, false
+	}
+	parts := strings.Split(v, ".")
+	nums := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return nil, false
+		}
+		nums = append(nums, n)
+	}
+	return nums, true
+}

--- a/internal/version/check_test.go
+++ b/internal/version/check_test.go
@@ -1,0 +1,197 @@
+package version
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// roundTripFunc 把函数适配为 http.RoundTripper。生产代码固定请求 api.github.com，
+// 测试经 Transport 拦截注入响应，不触网。
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func httpResp(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func releasePayload(tag, body string) string {
+	b, err := json.Marshal(map[string]any{"tag_name": tag, "body": body, "assets": []any{}})
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		latest, current string
+		want            bool
+	}{
+		{"v1.2.4", "v1.2.3", true},
+		{"v1.2.3", "v1.2.3", false},
+		{"v1.2.2", "v1.2.3", false},   // 回退不提醒
+		{"v1.3", "v1.2.9", true},      // 段数不同补零
+		{"v2", "v1.9.9", true},
+		{"1.2.4", "v1.2.3", true},     // v 前缀可省
+		{"v1.2.3-rc1", "v1.2.2", false}, // pre-release 解析失败 → 保守不提醒
+		{"nightly", "v1.0.0", false},
+		{"", "v1.0.0", false},
+		{"v1.2.4", "dev", false},      // dev 无版本语义
+	}
+	for _, c := range cases {
+		if got := isNewer(c.latest, c.current); got != c.want {
+			t.Fatalf("isNewer(%q, %q) = %v, want %v", c.latest, c.current, got, c.want)
+		}
+	}
+}
+
+func TestCheckUpdateDevSkipsNetwork(t *testing.T) {
+	calls := 0
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return httpResp(200, releasePayload("v9.9.9", "notes")), nil
+	})}
+	res, err := CheckUpdate(context.Background(), CheckOptions{
+		CurrentVersion: "dev",
+		Client:         client,
+	})
+	if err != nil {
+		t.Fatalf("CheckUpdate: %v", err)
+	}
+	if res.UpdateAvailable || calls != 0 {
+		t.Fatalf("dev 构建应跳过检查: res=%+v calls=%d", res, calls)
+	}
+}
+
+func TestCheckUpdateFetchesThenCaches(t *testing.T) {
+	calls := 0
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return httpResp(200, releasePayload("v1.2.4", "## New Features\n* feat: x")), nil
+	})}
+	cachePath := filepath.Join(t.TempDir(), "update-check.json")
+	opts := CheckOptions{CurrentVersion: "v1.2.3", Client: client, CachePath: cachePath}
+
+	res, err := CheckUpdate(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("first CheckUpdate: %v", err)
+	}
+	if !res.UpdateAvailable || res.Latest != "v1.2.4" || res.FromCache {
+		t.Fatalf("first result = %+v", res)
+	}
+	if res.Notes == "" {
+		t.Fatalf("release notes 应随结果带回")
+	}
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Fatalf("缓存未落盘: %v", err)
+	}
+
+	res2, err := CheckUpdate(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("second CheckUpdate: %v", err)
+	}
+	if !res2.FromCache {
+		t.Fatalf("第二次应命中缓存: %+v", res2)
+	}
+	if calls != 1 {
+		t.Fatalf("缓存节流失效: 联网 %d 次, want 1", calls)
+	}
+}
+
+func TestCheckUpdateCacheExpiry(t *testing.T) {
+	calls := 0
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return httpResp(200, releasePayload("v1.2.4", "")), nil
+	})}
+	cachePath := filepath.Join(t.TempDir(), "update-check.json")
+	// 距上次检查超过 MaxAge 的缓存应视为过期，重新联网。
+	stale := checkCache{LastCheck: time.Now().Add(-2 * time.Hour), Latest: "v1.2.4"}
+	if err := os.WriteFile(cachePath, mustJSON(stale), 0o644); err != nil {
+		t.Fatalf("write stale cache: %v", err)
+	}
+	_, err := CheckUpdate(context.Background(), CheckOptions{
+		CurrentVersion: "v1.2.3", Client: client, CachePath: cachePath, MaxAge: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("CheckUpdate: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("过期缓存应触发联网: calls=%d", calls)
+	}
+}
+
+func TestCheckUpdateStaleCacheFallback(t *testing.T) {
+	calls := 0
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return httpResp(500, "rate limited"), nil
+	})}
+	cachePath := filepath.Join(t.TempDir(), "update-check.json")
+	stale := checkCache{LastCheck: time.Now().Add(-48 * time.Hour), Latest: "v1.2.4", Notes: "old notes"}
+	if err := os.WriteFile(cachePath, mustJSON(stale), 0o644); err != nil {
+		t.Fatalf("write stale cache: %v", err)
+	}
+	res, err := CheckUpdate(context.Background(), CheckOptions{
+		CurrentVersion: "v1.2.3", Client: client, CachePath: cachePath,
+	})
+	if err != nil {
+		t.Fatalf("网络失败应回退过期缓存: %v", err)
+	}
+	if !res.FromCache || !res.UpdateAvailable {
+		t.Fatalf("fallback result = %+v", res)
+	}
+	if calls != 1 {
+		t.Fatalf("应先尝试联网再回退: calls=%d", calls)
+	}
+}
+
+func TestCheckUpdateErrorWithoutCache(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return httpResp(500, "boom"), nil
+	})}
+	_, err := CheckUpdate(context.Background(), CheckOptions{
+		CurrentVersion: "v1.2.3",
+		Client:         client,
+		CachePath:      filepath.Join(t.TempDir(), "absent.json"),
+	})
+	if err == nil {
+		t.Fatalf("无缓存且网络失败应返回 error 交调用方静默")
+	}
+}
+
+func TestCheckUpdateMissingTag(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return httpResp(200, `{"assets": []}`), nil
+	})}
+	_, err := CheckUpdate(context.Background(), CheckOptions{
+		CurrentVersion: "v1.2.3",
+		Client:         client,
+		CachePath:      filepath.Join(t.TempDir(), "absent.json"),
+	})
+	if err == nil {
+		t.Fatalf("release 缺 tag_name 应报错")
+	}
+}
+
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -32,6 +32,7 @@ type UpdateResult struct {
 
 type release struct {
 	TagName string         `json:"tag_name"`
+	Body    string         `json:"body"` // release notes 原文（markdown），版本检查提醒展示用
 	Assets  []releaseAsset `json:"assets"`
 }
 


### PR DESCRIPTION
## 概述

启动时后台检查 GitHub Releases，发现新版本后在欢迎页与事件流提示**版本号 + 更新内容**，是否升级始终由用户运行 `ainovel-cli update` 决定。

## 动机

`ainovel-cli update` 已提供完整的手动更新能力，但用户不主动执行就永远不知道有新版本。本 PR 补上"感知"一环：云端发版后，客户端下一次启动即可获知版本号与更新内容。

## 实现要点

- `internal/version/check.go`（新增）：
  - `CheckUpdate`：复用包内 `fetchRelease` 查询 latest release，返回版本比较结论与 release notes 原文
  - `isNewer`：轻量 semver 数字段比较（~30 行，不引第三方库）；任一段解析失败保守返回 false——宁可漏提醒不误提醒
  - 缓存节流：`<配置目录>/update-check.json` 记录上次检查，24h 内不重复联网（GitHub 匿名限流 60 req/h）；网络失败静默，有过期缓存则回退兜底
- `update.go`：`release` struct 增加 `Body` 字段（release notes 原文）
- TUI：`Init` 追加后台 Cmd（5s 超时，不阻塞启动）；命中新版本时事件流浮出一条 SYSTEM 事件（Summary 一行提醒，Detail 为完整 release notes 供右侧详情面板回看），欢迎屏同步显示一行升级入口提示
- 配置项 `disable_update_check`（默认开），尊重不需要提醒的用户
- `main.go` 的 `update` 命令改用 `version.DefaultRepo` 常量，消除魔法字符串

## 设计取舍

- **只提醒，不自动替换二进制**：升级动作始终由既有的 `ainovel-cli update`（含 SHA256 校验、原子替换）执行
- `dev` 构建（未注入版本号）与 headless 模式跳过检查
- Windows 上 `update` 仍提示手动下载（现有行为不变）；Windows 自更新支持另行 PR

## 测试

- `check_test.go`：`isNewer` 表驱动、缓存命中节流/过期重查/网络失败回退、`dev` 跳过、缺 tag 报错
- `go build ./... && go vet ./... && go test ./...` 全绿
- 真连 API 冒烟：`v0.0.1` 正确命中 `v0.7.7` 并带回 release notes
